### PR TITLE
Verify old password during password change

### DIFF
--- a/src/api/session/forgotApi.ts
+++ b/src/api/session/forgotApi.ts
@@ -10,6 +10,7 @@ export interface Response {
 interface ForgotEmail {
   email: string;
   password: string;
+  old_password: string;
 }
 
 interface Params {
@@ -19,10 +20,12 @@ interface Params {
 const forgotApi = ({
   userId,
   password,
+  old_password,
   authenticationToken,
 }: {
   userId: string;
   password: Params;
+  old_password: Params;
   authenticationToken: string;
 }): Promise<Response> =>
   fetchApiWithAuthRequest({
@@ -32,7 +35,7 @@ const forgotApi = ({
     headers: {
       'Content-Type': 'application/json',
     },
-    data: { password },
+    data: { password, old_password },
   });
 
 export default forgotApi;

--- a/src/api/session/forgotApi.ts
+++ b/src/api/session/forgotApi.ts
@@ -10,7 +10,6 @@ export interface Response {
 interface ForgotEmail {
   email: string;
   password: string;
-  old_password: string;
 }
 
 interface Params {
@@ -25,7 +24,7 @@ const forgotApi = ({
 }: {
   userId: string;
   password: Params;
-  old_password: Params;
+  old_password: string;
   authenticationToken: string;
 }): Promise<Response> =>
   fetchApiWithAuthRequest({

--- a/src/redux/actions/session/forgotAction.ts
+++ b/src/redux/actions/session/forgotAction.ts
@@ -4,11 +4,13 @@ import forgotApi from '../../../api/session/forgotApi';
 export const forgotAction = ({
   userId,
   password,
+  old_password,
   onSuccess,
   onFailure,
 }: {
   userId: string;
   password: string;
+  old_password: string;
   onSuccess?: () => void;
   onFailure?: () => void;
 }): TRequestAction => ({
@@ -23,6 +25,7 @@ export const forgotAction = ({
     params: {
       userId,
       password,
+      old_password,
     },
   },
 });

--- a/src/ui/layouts/session/ForgotPassword/useService.ts
+++ b/src/ui/layouts/session/ForgotPassword/useService.ts
@@ -30,6 +30,7 @@ export const useService = (): ServiceInterface => {
           forgotAction({
             userId: '',
             password: '',
+            old_password: '',
             onFailure: () => {
               dispatch(
                 showToasterAction({

--- a/src/ui/layouts/settings/PasswordPopup.tsx
+++ b/src/ui/layouts/settings/PasswordPopup.tsx
@@ -69,42 +69,26 @@ export const PasswordPopup: React.FC<{
     } else {
       setSubmitting(true);
       dispatch(
-        loginAction({
-          password: currentPassword,
-          username: username,
-          onFailure: (err) => {
+        sessionActions.forgotPassword({
+          userId: user?.id,
+          password: newPassword,
+          old_password: currentPassword,
+          // @ts-ignore
+          onFailure: (errorText) => {
+            setSubmitting(false);
             dispatch(
               showToasterAction({
-                description: err,
+                description: errorText,
                 type: toasterTypes.failure,
               }),
             );
-            setSubmitting(false);
           },
-          onSuccess: async () => {
-            dispatch(
-              sessionActions.forgotPassword({
-                userId: user?.id,
-                password: newPassword,
-                // @ts-ignore
-                onFailure: (errorText) => {
-                  setSubmitting(false);
-                  dispatch(
-                    showToasterAction({
-                      description: errorText,
-                      type: toasterTypes.failure,
-                    }),
-                  );
-                },
-                onSuccess: () => {
-                  setSubmitting(false);
-                  setPasswordSuccess(true);
-                  setNewPassword('');
-                  setConfirmPassword('');
-                  setCurrentPassword('');
-                },
-              }),
-            );
+          onSuccess: () => {
+            setSubmitting(false);
+            setPasswordSuccess(true);
+            setNewPassword('');
+            setConfirmPassword('');
+            setCurrentPassword('');
           },
         }),
       );


### PR DESCRIPTION
The new password change workflow requires that the old password is verified during a password change. This PR updates the password change form to send the current password along to the API and at the same time removes the pre-check that runs the current password through the login endpoint to verify it, as that's no longer necessary.

Related to https://github.com/zenml-io/zenml/pull/2587 changes in the API