### PR TITLE
Add Local Banner

### DIFF
--- a/src/layouts/AuthenticatedLayout/AuthenticatedHeader.tsx
+++ b/src/layouts/AuthenticatedLayout/AuthenticatedHeader.tsx
@@ -6,7 +6,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 
 export function AuthenticatedHeader() {
 	return (
-		<header className="sticky top-0 z-10 h-9 border-b border-theme-border-moderate bg-theme-surface-primary">
+		<header className="h-9 border-b border-theme-border-moderate bg-theme-surface-primary">
 			<div className="flex h-full items-center justify-between">
 				<Link
 					aria-label="Go to organizations page"

--- a/src/layouts/AuthenticatedLayout/LocalBanner.tsx
+++ b/src/layouts/AuthenticatedLayout/LocalBanner.tsx
@@ -1,0 +1,32 @@
+import ZenMLIcon from "@/assets/icons/zenml-icon.svg?react";
+import { Button } from "@zenml-io/react-component-library";
+import { useServerInfo } from "@/data/server/info-query";
+
+export function LocalBanner() {
+	const serverInfo = useServerInfo();
+
+	if (serverInfo.data?.deployment_type !== "local") return null;
+
+	return (
+		<aside className="flex h-9 items-center justify-between gap-2 bg-warning-400 px-4 py-3">
+			<div className="flex items-center gap-3 truncate">
+				<ZenMLIcon className="h-5 w-5 shrink-0" />
+				<p className="font-semibold">You are running a local version of ZenML.</p>
+				<p className="truncate">
+					Please consider deploying it yourself or signing up for ZenML Pro for easy deployment,
+					enhanced features, and support.
+				</p>
+			</div>
+			<Button
+				asChild
+				intent="secondary"
+				className="whitespace-nowrap bg-theme-surface-primary"
+				size="md"
+			>
+				<a href="https://cloud.zenml.io/signup" rel="noopener noreferrer" target="_blank">
+					Try ZenML Pro
+				</a>
+			</Button>
+		</aside>
+	);
+}

--- a/src/layouts/AuthenticatedLayout/Sidebar.tsx
+++ b/src/layouts/AuthenticatedLayout/Sidebar.tsx
@@ -23,12 +23,17 @@ import { Link, LinkProps, matchPath, useLocation } from "react-router-dom";
 import { OnboardingItem } from "./OnboardingItem";
 import { SidebarImage, SidebarTitle } from "./SidebarFragments";
 import { WhatsNewButton } from "./WhatsNewButton";
+import { useServerInfo } from "../../data/server/info-query";
 
 export function Sidebar() {
 	const { setIsOpen, isOpen } = useSidebarContext();
+	const serverInfo = useServerInfo();
+	const isLocal = serverInfo.data?.deployment_type === "local";
 	return (
 		<div>
-			<ZenMLSidebar className="sticky top-9 h-[calc(100vh_-_64px)] overflow-y-auto overflow-x-clip">
+			<ZenMLSidebar
+				className={`sticky  ${isLocal ? "top-[128px] h-[calc(100vh_-_64px_-_64px)]" : "top-9 h-[calc(100vh_-_64px)]"} overflow-y-auto overflow-x-clip`}
+			>
 				<div className="flex w-full flex-1 flex-col gap-0.5 self-start">
 					<SidebarHeader
 						icon={

--- a/src/layouts/AuthenticatedLayout/index.tsx
+++ b/src/layouts/AuthenticatedLayout/index.tsx
@@ -1,13 +1,14 @@
+import { Analytics } from "@/components/Analytics";
+import { ProductTour } from "@/components/tour/Tour";
 import { useCurrentUser } from "@/data/users/current-user-query";
+import { checkUserOnboarding } from "@/lib/user";
+import { routes } from "@/router/routes";
 import { SidebarProvider } from "@zenml-io/react-component-library";
 import { Navigate, Outlet } from "react-router-dom";
 import { AuthenticatedHeader } from "./AuthenticatedHeader";
-import { Sidebar } from "./Sidebar";
-import { routes } from "@/router/routes";
-import { checkUserOnboarding } from "@/lib/user";
-import { Analytics } from "@/components/Analytics";
-import { ProductTour } from "@/components/tour/Tour";
 import { BreadcrumbsContextProvider } from "./BreadcrumbsContext";
+import { LocalBanner } from "./LocalBanner";
+import { Sidebar } from "./Sidebar";
 
 export function AuthenticatedLayout() {
 	const { data } = useCurrentUser();
@@ -26,7 +27,10 @@ export function AuthenticatedLayout() {
 	return (
 		<div className="relative flex min-h-screen w-full flex-col">
 			<BreadcrumbsContextProvider currentBreadcrumbData={null} setCurrentBreadcrumbData={null}>
-				<AuthenticatedHeader />
+				<div className="sticky top-0 z-10">
+					<LocalBanner />
+					<AuthenticatedHeader />
+				</div>
 				<main className="flex flex-grow flex-col">
 					<div className="flex flex-grow">
 						<SidebarProvider initialOpen={isMinWidth}>


### PR DESCRIPTION

<img width="1728" alt="Bildschirmfoto 2024-07-02 um 09 49 57" src="https://github.com/zenml-io/zenml-dashboard/assets/43843195/2db52a15-23fa-4def-96ac-0e8b5b36fbd0">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `LocalBanner` component that displays a message for local deployments in ZenML.

- **Changes**
  - Updated header positioning in authenticated layout by removing `sticky` and `top-0` classes.
  - Sidebar now adjusts its styling based on local deployment status using server info.

- **Refactor**
  - Reorganized import order and component structure within the `AuthenticatedLayout`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->