### PR TITLE
Add e2e tests for login, survey and dashboard

### DIFF
--- a/e2e-tests/dashboard.spec.ts
+++ b/e2e-tests/dashboard.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import { login } from "./utils";
+
+test.describe("Dashboard", () => {
+	test("Check dashboard and Navbar", async ({ page }) => {
+		await login(page);
+
+		const overviewLink = await page.locator('a:has-text("Overview")').isVisible();
+
+		if (!overviewLink) {
+			return;
+		}
+		//Visible the navbar
+		await expect(page.locator('a:has-text("Pipelines")')).toBeVisible();
+		await expect(page.locator('a:has-text("Models")')).toBeVisible();
+		await expect(page.locator('a:has-text("Artifacts")')).toBeVisible();
+		await expect(page.locator('a:has-text("Stacks")')).toBeVisible();
+
+		//Change the URL by clicking each nav item
+		await page.click('a:has-text("Pipelines")');
+		await expect(page).toHaveURL(/\/pipelines\?tab=pipelines/);
+
+		await page.click('a:has-text("Models")');
+		await expect(page).toHaveURL(/\/models/);
+
+		await page.click('a:has-text("Artifacts")');
+		await expect(page).toHaveURL(/\/artifacts/);
+
+		await page.click('a:has-text("Stacks")');
+		await expect(page).toHaveURL(/\/stacks/);
+	});
+});

--- a/e2e-tests/login.spec.ts
+++ b/e2e-tests/login.spec.ts
@@ -1,0 +1,8 @@
+import { test } from "@playwright/test";
+import { login } from "./utils";
+
+test.describe("Login", () => {
+	test("Login with default username", async ({ page }) => {
+		await login(page);
+	});
+});

--- a/e2e-tests/survey.spec.ts
+++ b/e2e-tests/survey.spec.ts
@@ -1,0 +1,45 @@
+import { test } from "@playwright/test";
+import { login } from "./utils";
+
+test.describe("Survey", () => {
+	test("Fill survey for first time", async ({ page }) => {
+		await login(page);
+
+		const isVisible = await page.locator("text=Add your account details").isVisible();
+
+		if (!isVisible) {
+			return;
+		}
+
+		//survey form - Step 1
+		await page.fill('input[name="fullName"]', "test");
+		await page.fill('input[name="email"]', "test@test.com");
+		await page
+			.getByLabel("I want to receive news and recommendations about how to use ZenML")
+			.check();
+		await page.click('button span:has-text("Continue")');
+		await page.waitForSelector("text=What will be your primary use for ZenML?");
+
+		//survey form - Step 2
+		await page.click('div label:has-text("Personal")');
+		await page.click('button span:has-text("Continue")');
+		await page.waitForSelector("text=What best describes your current situation with ZenML?");
+
+		//survey form - Step 3
+		await page.check('label:has-text("I\'m new to MLOps and exploring")');
+		await page.click('button span:has-text("Continue")');
+		await page.waitForSelector("text=What is your current infrastructure?");
+
+		//survey form - Step 4
+		await page.check('label:has-text("GCP") button');
+		await page.check('label:has-text("Azure")');
+		await page.check('label:has-text("Openshift")');
+		await page.check('label:has-text("AWS")');
+		await page.check('label:has-text("Native Kubernetes")');
+		await page.click('button span:has-text("Continue")');
+		await page.waitForSelector("text=Join The ZenML Slack Community");
+
+		//survey form - Step 5
+		await page.click('button span:has-text("Skip")');
+	});
+});

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -1,0 +1,10 @@
+import { Page, expect } from "@playwright/test";
+
+// reusable login function
+export async function login(page: Page) {
+	await page.goto("http://127.0.0.1:8237/");
+	await expect(page.locator('h1:has-text("Log in to your account")')).toBeVisible();
+	await page.fill('input[name="username"]', "default");
+	await page.fill('input[name="password"]', "");
+	await page.click('button span:has-text("Login")');
+}


### PR DESCRIPTION
To add e2e tests for Login page, Survey form and dashboard's home page.

```bash
$ cd e2e-tests 
$ npx playwright test       

Running 5 tests using 4 workers

  ✓  1 example.spec.ts:3:1 › has title (902ms)
  ✓  2 dashboard.spec.ts:5:2 › Dashboard › Check dashboard and Navbar (1.1s)
  ✓  3 survey.spec.ts:5:2 › Survey › Fill survey for first time (1.1s)
  ✓  4 login.spec.ts:5:2 › Login › Login with default username (1.1s)
  ✓  5 example.spec.ts:10:1 › get started link (807ms)

  5 passed (2.8s)
```