### PR TITLE
Fix the wget command to print output on screen same as curl

### DIFF
--- a/src/app/settings/api-tokens/APITokenModal.tsx
+++ b/src/app/settings/api-tokens/APITokenModal.tsx
@@ -215,5 +215,5 @@ function getCurlCommand(token: string, endpoint: string) {
 }
 
 function getWgetCommand(token: string, endpoint: string) {
-	return `wget --header="Authorization: Bearer ${token}" "${encodeURI(endpoint)}"`;
+	return `wget -qO- --header="Authorization: Bearer ${token}" "${encodeURI(endpoint)}"`;
 }


### PR DESCRIPTION
The current `wget` command shown in the API token screen will save the server response to a file and print some irrelevant data on screen, unlike `curl`, which prints the server response on screen and nothing else.

The updated `wget` command will achieve the same result as `curl`.