### PR TITLE
Add Claude Code GitHub Actions workflows

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,0 +1,15 @@
+---
+internal:
+  - '@htahir1'
+  - '@hamza-zenml'
+  - '@bcdurak'
+  - '@baris-zenml'
+  - '@michael-zenml'
+  - '@schustmi'
+  - '@strickvl'
+  - '@alex-zenml'
+  - '@alexej-zenml'
+  - '@AlexejPenner'
+  - '@stefannica'
+  - '@safoinme'
+  - '@Cahllagerfeld'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,150 @@
+---
+name: Claude Code Review
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  check-team-member:
+    runs-on: ubuntu-latest
+    outputs:
+      is-team-member: ${{ steps.check.outputs.is-member }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Check if actor is team member
+        id: check
+        run: |
+          ACTOR="${{ github.actor }}"
+          if grep -q "@${ACTOR}" .github/teams.yml; then
+            echo "is-member=true" >> $GITHUB_OUTPUT
+            echo "✅ $ACTOR is a team member"
+          else
+            echo "is-member=false" >> $GITHUB_OUTPUT
+            echo "❌ $ACTOR is not a team member"
+          fi
+  claude-review:
+    needs: check-team-member
+    if: |
+      needs.check-team-member.outputs.is-team-member == 'true' &&
+      github.actor != 'github-actions[bot]' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude /full-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: claude-review-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY }}
+          track_progress: true
+          prompt: |
+            You are reviewing frontend code changes for the ZenML Dashboard (OSS) with git diffs included in the prompt. Focus on ensuring the changes are sound, clean, intentional, and void of regressions.
+            
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            
+            Context:
+            - You can fetch additional PR context via:
+              - gh pr view ${{ github.event.pull_request.number }} --json title,body,author,headRefName,baseRefName,commits
+              - gh pr diff ${{ github.event.pull_request.number }} --name-only
+            - Use the repository's CLAUDE.md and AGENTS.md for conventions and patterns.
+            - This is a Vite + React SPA using TanStack Query, React Router, Tailwind CSS, and TypeScript.
+            - UI components come from @zenml-io/react-component-library (never import from lucide-react).
+            
+            Primary Review Goals:
+            
+            1) Verify Change Correctness
+               - Confirm the changes achieve their intended purpose
+               - Check for unintended side effects or regressions
+               - Validate edge cases are handled properly
+               - Ensure error paths are covered
+               - Verify accessibility (a11y) considerations for UI changes
+            
+            2) Code Quality & Cleanliness
+               - Is the code readable and self-documenting?
+               - Are the changes minimal and focused?
+               - Do they follow existing patterns in the codebase?
+               - Are there any code smells or anti-patterns?
+               - No `type any` usage - proper TypeScript types required
+               - No inline styles - Tailwind utilities only
+               - No console.log statements left in code
+            
+            3) Frontend-Specific Quality Checks
+               - Component reusability: Are components focused and composable?
+               - React patterns: Proper hook usage, no rules violations
+               - TanStack Query hygiene:
+                 * Proper query key factories (matching API paths)
+                 * Query invalidation after mutations
+                 * One request per endpoint in src/data/<resource>/
+               - Router discipline: Using routes.tsx helpers, not hard-coded paths
+               - Icons: Using assets/ components, NOT lucide-react imports
+               - Styling: Tailwind utilities, proper use of @zenml-io/react-component-library
+               - Type safety: Using generated types from src/types/core.ts
+               - Performance: Unnecessary re-renders, bundle size impact
+            
+            4) Intentionality Check
+               - Does every change have a clear purpose?
+               - Are there any accidental modifications?
+               - Is there dead code being introduced?
+               - Are the commit boundaries logical?
+            
+            5) Potential Issues to Flag
+               - Performance degradations (bundle size, unnecessary re-renders)
+               - Security vulnerabilities (XSS, injection, etc.)
+               - Race conditions in async operations
+               - Memory leaks (uncleaned effects, event listeners)
+               - Breaking changes to component APIs or data contracts
+               - Backwards compatibility issues (dashboard supports multiple ZenML versions)
+            
+            6) Constructive Suggestions
+               - Alternative approaches that might be cleaner
+               - Opportunities to reduce complexity
+               - Missing test coverage for critical paths
+               - Documentation gaps for complex logic
+               - Accessibility improvements
+            
+            Documentation & Testing Review:
+            - Determine if user-facing behavior, APIs, or component interfaces have changed.
+            - Heuristics (run): gh pr diff ${{ github.event.pull_request.number }} --name-only
+              - If changes exist in src/app/, src/components/, or src/lib/ but README.md, CLAUDE.md, or AGENTS.md are not updated, flag as "docs update needed".
+              - If component APIs changed, check for updates to JSDoc comments or usage examples.
+              - If new environment variables added, ensure .env.example is updated.
+              - If OpenAPI types changed (src/types/core.ts), verify it was generated not hand-edited.
+            - Testing requirements:
+              - Unit tests (*.spec.ts) for new utilities in src/lib/
+              - E2E tests (e2e-tests/) for new user flows
+              - Suggest test coverage for critical business logic
+              - Verify test commands: pnpm test:unit, pnpm test:e2e, pnpm lint, pnpm build
+            - If migration or breaking changes are introduced, recommend adding explicit notes.
+            
+            Review Format:
+            - Start with a summary of what the changes accomplish.
+            - List any critical issues that must be addressed.
+            - Note minor improvements that would enhance quality.
+            - Acknowledge what's done particularly well.
+            - End with specific, actionable next steps if needed.
+            
+            Output Instructions:
+            - Provide detailed feedback using inline-style code references in your comment for specific issues (quote file paths and line ranges when possible).
+            - Use top-level comments for general observations or praise.
+            - Use `gh pr comment` to post your review comment to the PR.
+            
+            Be constructive and helpful in your feedback.
+          claude_args: --max-turns 5 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
+            issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh
+            pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,78 @@
+---
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+jobs:
+  check-team-member:
+    runs-on: ubuntu-latest
+    outputs:
+      is-team-member: ${{ steps.check.outputs.is-member }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Check if actor is team member
+        id: check
+        run: |
+          ACTOR="${{ github.actor }}"
+          if grep -q "@${ACTOR}" .github/teams.yml; then
+            echo "is-member=true" >> $GITHUB_OUTPUT
+            echo "✅ $ACTOR is a team member"
+          else
+            echo "is-member=false" >> $GITHUB_OUTPUT
+            echo "❌ $ACTOR is not a team member"
+          fi
+  claude:
+    needs: check-team-member
+    if: |
+      needs.check-team-member.outputs.is-team-member == 'true' &&
+      github.actor != 'github-actions[bot]' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read  # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY }}
+          track_progress: true
+
+          # This allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: --max-turns 5 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
+            issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh
+            pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to enable Claude Code assistant for PR reviews and general support:

- **claude-code-review.yml**: Comprehensive code reviews triggered by `@claude /full-review` in PR comments
- **claude.yml**: General assistance triggered by `@claude` mentions in PRs, issues, and reviews
- **teams.yml**: Team member list for access control

Both workflows are adapted from backend templates with frontend-specific review criteria:
- React/TypeScript/Vite patterns
- TanStack Query hygiene (query keys, invalidation)
- Component library usage (@zenml-io/react-component-library)
- Tailwind styling conventions
- Router discipline (routes.tsx helpers)
- Bundle size and performance considerations
- Accessibility checks

## Verification

- [x] Workflows follow GitHub Actions best practices
- [x] Team member verification via teams.yml
- [x] Frontend-specific review criteria included
- [x] CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY secret assumed configured
- [x] Allowed tools properly restricted for security

## Testing Plan

Once merged to staging:
- [ ] Test `@claude` mention in a PR comment
- [ ] Test `@claude /full-review` in a PR comment
- [ ] Verify team member access control works
- [ ] Verify non-team members are blocked