### PR TITLE
Fix GitHub Actions workflows for Claude and Codex

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,8 +49,10 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             You are reviewing frontend code changes for the ZenML Dashboard (OSS) with git diffs included in the prompt. Focus on ensuring the changes are sound, clean, intentional, and void of regressions.
@@ -145,6 +147,6 @@ jobs:
             - Use `gh pr comment` to post your review comment to the PR.
             
             Be constructive and helpful in your feedback.
-          claude_args: --max-turns 5 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
+          claude_args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
             issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh
             pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,9 +36,9 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/full-review')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/full-review')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '/full-review')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
@@ -60,8 +60,10 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
 
           # This allows Claude to read CI results on PRs
@@ -73,6 +75,6 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: --max-turns 5 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
+          claude_args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
             issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh
             pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -71,6 +71,8 @@ jobs:
         id: codex_comment
         if: steps.mode.outputs.mode == 'comment'
         uses: openai/codex-action@v1
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt: |
@@ -88,9 +90,11 @@ jobs:
         id: codex_full_review
         if: steps.mode.outputs.mode == 'full-review'
         uses: openai/codex-action@v1
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          codex-args: --max-turns 5 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+          codex-args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
           prompt: |
             You are Codex reviewing frontend code changes for the ZenML Dashboard (OSS) with git diffs available locally.
 


### PR DESCRIPTION
## Summary
This PR fixes several issues with the GitHub Actions workflows for Claude Code and Codex:

- **Environment variables**: Added `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` as environment variables to the respective workflow steps
- **Secret naming**: Renamed `CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY` to the standard `ANTHROPIC_API_KEY`
- **Duplicate workflow prevention**: Updated `claude.yml` to skip execution when `/full-review` is mentioned, preventing duplication with `claude-code-review.yml`
- **Turn limit removal**: Removed `--max-turns 5` from all workflows to allow natural completion

## Changes
- `.github/workflows/claude.yml`: Added env var, updated secret name, added `/full-review` exclusion, removed max-turns
- `.github/workflows/claude-code-review.yml`: Added env var, updated secret name, removed max-turns
- `.github/workflows/codex-comment.yml`: Added env var, removed max-turns

## Test plan
- [ ] Verify Claude workflow triggers correctly on `@claude` mentions (but not `/full-review`)
- [ ] Verify Claude Code Review workflow triggers on `@claude /full-review`
- [ ] Verify Codex workflow triggers correctly on `@codex` mentions
- [ ] Confirm environment variables are properly set in workflow runs