### PR TITLE
Fix Bulk Delete Runs from Pipeline

### DIFF
--- a/src/app/pipelines/[pipelineId]/runs/RunsTable.tsx
+++ b/src/app/pipelines/[pipelineId]/runs/RunsTable.tsx
@@ -36,6 +36,7 @@ export function PipelineRunsTable({ params, columns }: Props) {
 				<DataTable
 					rowSelection={rowSelection}
 					onRowSelectionChange={setRowSelection}
+					getRowId={(row) => row.id}
 					columns={columns}
 					data={data.items}
 				/>


### PR DESCRIPTION
Fixes a bug, where the bulk-deletion in a pipeline failed, because it used an index, and not the actual id to delete the run