### PR TITLE
Add warning if sensitive values in Dockerfile

### DIFF
--- a/src/components/collapsibles/docker-image-collapsible.tsx
+++ b/src/components/collapsibles/docker-image-collapsible.tsx
@@ -1,4 +1,11 @@
 import ChevronDown from "@/assets/icons/chevron-down.svg?react";
+import Redirect from "@/assets/icons/redirect.svg?react";
+import Docker from "@/assets/icons/services/docker.svg?react";
+import { Codesnippet } from "@/components/CodeSnippet";
+import { CopyButton } from "@/components/CopyButton";
+import { KeyValue } from "@/components/KeyValue";
+import { extractDockerImageKey } from "@/lib/strings";
+import { BuildItem } from "@/types/pipeline-builds";
 import {
 	CollapsibleContent,
 	CollapsibleHeader,
@@ -7,14 +14,7 @@ import {
 	Tag
 } from "@zenml-io/react-component-library";
 import { useState } from "react";
-import Docker from "@/assets/icons/services/docker.svg?react";
-import Redirect from "@/assets/icons/redirect.svg?react";
-import { CopyButton } from "@/components/CopyButton";
-import { Codesnippet } from "@/components/CodeSnippet";
-import { KeyValue } from "@/components/KeyValue";
-import { BuildItem } from "@/types/pipeline-builds";
-import { extractDockerImageKey } from "@/lib/strings";
-import { sanitizeDockerfile } from "./docker-image";
+import { DockerfileSnippet } from "./dockerfile-snippet";
 
 type Props = {
 	data: BuildItem;
@@ -76,19 +76,7 @@ export function DockerImageCollapsible({ data, displayCopyButton = true }: Props
 						}
 					/>
 				</dl>
-				{data.dockerfile && (
-					<>
-						<p className="mb-2 mt-5 text-theme-text-secondary">Dockerfile</p>
-						<Codesnippet
-							highlightCode
-							language="dockerfile"
-							fullWidth
-							wrap
-							code={sanitizeDockerfile(data.dockerfile)}
-							copyCode={data.dockerfile}
-						/>
-					</>
-				)}
+				{data.dockerfile && <DockerfileSnippet dockerfile={data.dockerfile} />}
 				{data.requirements && (
 					<>
 						<p className="mb-2 mt-5 text-theme-text-secondary">Requirements</p>

--- a/src/components/collapsibles/docker-image.spec.ts
+++ b/src/components/collapsibles/docker-image.spec.ts
@@ -5,38 +5,44 @@ describe("sanitizeDockerfile", () => {
 	describe("sensitive variables", () => {
 		it("should mask API_KEY values", () => {
 			const input = "ENV OPENAI_API_KEY=sk-abc123def456";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV OPENAI_API_KEY=***************"); // 15 chars
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV OPENAI_API_KEY=***************"); // 15 chars
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask SECRET values", () => {
 			const input = "ENV DATABASE_SECRET=my-secret-value";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV DATABASE_SECRET=***************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV DATABASE_SECRET=***************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask TOKEN values", () => {
 			const input = "ENV AUTH_TOKEN=bearer-token-12345";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV AUTH_TOKEN=******************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV AUTH_TOKEN=******************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask PASSWORD values", () => {
 			const input = "ENV DB_PASSWORD=super-secret-password";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV DB_PASSWORD=*********************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV DB_PASSWORD=*********************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask values ending with KEY", () => {
 			const input = "ENV PRIVATE_KEY=rsa-private-key-data";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV PRIVATE_KEY=********************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV PRIVATE_KEY=********************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask CREDENTIALS values", () => {
 			const input = "ENV AWS_CREDENTIALS=credential-string";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV AWS_CREDENTIALS=*****************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV AWS_CREDENTIALS=*****************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask values with different sensitive suffixes", () => {
@@ -50,8 +56,9 @@ describe("sanitizeDockerfile", () => {
 			];
 
 			inputs.forEach((input) => {
-				const output = sanitizeDockerfile(input);
-				expect(output).toContain("=********");
+				const result = sanitizeDockerfile(input);
+				expect(result.sanitized).toContain("=********");
+				expect(result.hasSensitiveValues).toBe(true);
 			});
 		});
 	});
@@ -59,116 +66,133 @@ describe("sanitizeDockerfile", () => {
 	describe("non-sensitive variables", () => {
 		it("should preserve NODE_ENV values", () => {
 			const input = "ENV NODE_ENV=production";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV NODE_ENV=production");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV NODE_ENV=production");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should preserve PORT values", () => {
 			const input = "ENV PORT=3000";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV PORT=3000");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV PORT=3000");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should preserve PATH values", () => {
 			const input = "ENV PATH=/usr/local/bin:$PATH";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV PATH=/usr/local/bin:$PATH");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV PATH=/usr/local/bin:$PATH");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should preserve ENVIRONMENT values", () => {
 			const input = "ENV ENVIRONMENT=staging";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV ENVIRONMENT=staging");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV ENVIRONMENT=staging");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should preserve DEBUG values", () => {
 			const input = "ENV DEBUG=true";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV DEBUG=true");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV DEBUG=true");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 	});
 
 	describe("quoted values", () => {
 		it("should mask quoted sensitive values (double quotes)", () => {
 			const input = 'ENV API_KEY="sk-abc123def456"';
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 			// Function removes quotes and masks the value inside (15 chars)
-			expect(output).toBe("ENV API_KEY=***************");
+			expect(result.sanitized).toBe("ENV API_KEY=***************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask quoted sensitive values (single quotes)", () => {
 			const input = "ENV SECRET='my-secret-value'";
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 			// Function removes quotes and masks the value inside
-			expect(output).toBe("ENV SECRET=***************");
+			expect(result.sanitized).toBe("ENV SECRET=***************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should preserve quoted non-sensitive values", () => {
 			const input = 'ENV NODE_ENV="production"';
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe('ENV NODE_ENV="production"');
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe('ENV NODE_ENV="production"');
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should handle empty quoted values for sensitive vars", () => {
 			const input = 'ENV API_KEY=""';
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 			// Empty string inside quotes results in minimum 1 star
-			expect(output).toBe("ENV API_KEY=*");
+			expect(result.sanitized).toBe("ENV API_KEY=*");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 	});
 
 	describe("separator styles", () => {
 		it("should handle ENV with = separator", () => {
 			const input = "ENV API_KEY=secret-value";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY=************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY=************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle ENV with space separator", () => {
 			const input = "ENV API_KEY secret-value";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY ************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY ************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle ENV with spaces around = separator", () => {
 			const input = "ENV API_KEY = secret-value";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY = ************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY = ************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 	});
 
 	describe("line continuations", () => {
 		it("should handle line continuation with backslash", () => {
 			const input = "ENV API_KEY=secret-value \\";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY=************ \\");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY=************ \\");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should preserve trailing whitespace with backslash", () => {
 			const input = "ENV SECRET=value123  \\\n";
-			const output = sanitizeDockerfile(input);
-			expect(output).toContain("********");
-			expect(output).toContain("\\");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toContain("********");
+			expect(result.sanitized).toContain("\\");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 	});
 
 	describe("whitespace handling", () => {
 		it("should handle leading whitespace", () => {
 			const input = "  ENV API_KEY=secret";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("  ENV API_KEY=******");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("  ENV API_KEY=******");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle trailing whitespace", () => {
 			const input = "ENV API_KEY=secret  ";
-			const output = sanitizeDockerfile(input);
-			expect(output).toContain("******");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toContain("******");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle tabs", () => {
 			const input = "\tENV API_KEY=secret-value";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("\tENV API_KEY=************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("\tENV API_KEY=************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 	});
 
@@ -180,14 +204,15 @@ ENV PORT=8080
 ENV DATABASE_PASSWORD=db-secret
 ENV DEBUG=true`;
 
-			const output = sanitizeDockerfile(input);
-			const lines = output.split("\n");
+			const result = sanitizeDockerfile(input);
+			const lines = result.sanitized.split("\n");
 
 			expect(lines[0]).toBe("ENV NODE_ENV=production");
 			expect(lines[1]).toBe("ENV API_KEY=*********");
 			expect(lines[2]).toBe("ENV PORT=8080");
 			expect(lines[3]).toBe("ENV DATABASE_PASSWORD=*********");
 			expect(lines[4]).toBe("ENV DEBUG=true");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle full Dockerfile with ENV statements", () => {
@@ -201,71 +226,81 @@ RUN npm install
 ENV DATABASE_SECRET=super-secret-db-key
 CMD ["npm", "start"]`;
 
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 
-			expect(output).toContain("FROM node:18");
-			expect(output).toContain("ENV NODE_ENV=production");
-			expect(output).toContain("ENV API_KEY=*******************"); // 20 chars masked -> 19 stars
-			expect(output).toContain("ENV PORT=3000");
-			expect(output).toContain("ENV DATABASE_SECRET=*******************"); // 20 chars masked -> 19 stars
-			expect(output).toContain('CMD ["npm", "start"]');
+			expect(result.sanitized).toContain("FROM node:18");
+			expect(result.sanitized).toContain("ENV NODE_ENV=production");
+			expect(result.sanitized).toContain("ENV API_KEY=*******************"); // 20 chars masked -> 19 stars
+			expect(result.sanitized).toContain("ENV PORT=3000");
+			expect(result.sanitized).toContain("ENV DATABASE_SECRET=*******************"); // 20 chars masked -> 19 stars
+			expect(result.sanitized).toContain('CMD ["npm", "start"]');
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 	});
 
 	describe("edge cases", () => {
 		it("should handle empty value for sensitive variable", () => {
 			const input = "ENV API_KEY=";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY=");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY=");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should handle single character sensitive value", () => {
 			const input = "ENV SECRET=x";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV SECRET=*");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV SECRET=*");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle very long sensitive values", () => {
 			const longValue = "a".repeat(100);
 			const input = `ENV API_KEY=${longValue}`;
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe(`ENV API_KEY=${"*".repeat(100)}`);
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe(`ENV API_KEY=${"*".repeat(100)}`);
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle special characters in sensitive values", () => {
 			const input = "ENV API_KEY=key-with-@#$%^&*()";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY=******************"); // 19 chars
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY=******************"); // 19 chars
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle special characters in non-sensitive values", () => {
 			const input = "ENV PATH=/usr/bin:$PATH:/opt/bin";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV PATH=/usr/bin:$PATH:/opt/bin");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV PATH=/usr/bin:$PATH:/opt/bin");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should be case-insensitive for variable names", () => {
 			const input = "ENV api_key=secret";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV api_key=******");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV api_key=******");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle uppercase KEY suffix", () => {
 			const input = "ENV MY_SPECIAL_KEY=value";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV MY_SPECIAL_KEY=*****");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV MY_SPECIAL_KEY=*****");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should not mask if KEY is not a suffix", () => {
 			const input = "ENV KEYBOARD_LAYOUT=us";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV KEYBOARD_LAYOUT=us");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV KEYBOARD_LAYOUT=us");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should handle mixed case in variable names", () => {
 			const input = "ENV My_Api_Key=secret123";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV My_Api_Key=*********");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV My_Api_Key=*********");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle non-ENV Docker instructions", () => {
@@ -275,19 +310,21 @@ COPY . /app
 ENV API_KEY=secret
 EXPOSE 8080`;
 
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 
-			expect(output).toContain("FROM ubuntu");
-			expect(output).toContain("RUN apt-get update");
-			expect(output).toContain("COPY . /app");
-			expect(output).toContain("ENV API_KEY=******");
-			expect(output).toContain("EXPOSE 8080");
+			expect(result.sanitized).toContain("FROM ubuntu");
+			expect(result.sanitized).toContain("RUN apt-get update");
+			expect(result.sanitized).toContain("COPY . /app");
+			expect(result.sanitized).toContain("ENV API_KEY=******");
+			expect(result.sanitized).toContain("EXPOSE 8080");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should return empty string for empty input", () => {
 			const input = "";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should handle Dockerfile with no ENV statements", () => {
@@ -297,97 +334,111 @@ COPY . .
 RUN npm install
 CMD ["npm", "start"]`;
 
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe(input);
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe(input);
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 	});
 
 	describe("value length preservation", () => {
 		it("should mask with correct number of stars for unquoted values", () => {
 			const input = "ENV API_KEY=12345";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY=*****");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY=*****");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask with correct number of stars for quoted values", () => {
 			const input = 'ENV API_KEY="12345"';
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 			// Should count only the value inside quotes (5 chars), quotes are removed
-			expect(output).toBe("ENV API_KEY=*****");
+			expect(result.sanitized).toBe("ENV API_KEY=*****");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle minimum length of 1 star", () => {
 			const input = "ENV SECRET=a";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV SECRET=*");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV SECRET=*");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 	});
 
 	describe("additional edge cases", () => {
 		it("should mask when variable name IS the sensitive keyword", () => {
 			const input = "ENV KEY=my-value";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV KEY=********");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV KEY=********");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask SECRET when it is the full variable name", () => {
 			const input = "ENV SECRET=confidential";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV SECRET=************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV SECRET=************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask TOKEN when it is the full variable name", () => {
 			const input = "ENV TOKEN=bearer-token";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV TOKEN=************");
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV TOKEN=************");
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should mask PASSWORD when it is the full variable name", () => {
 			const input = "ENV PASSWORD=secret123";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV PASSWORD=*********"); // 9 chars
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV PASSWORD=*********"); // 9 chars
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should NOT mask CONNECTION_STRING (doesn't end with sensitive suffix)", () => {
 			const input = "ENV CONNECTION_STRING=server=localhost;key=secret123";
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 			// CONNECTION_STRING doesn't end with a sensitive suffix, so it's preserved
-			expect(output).toBe("ENV CONNECTION_STRING=server=localhost;key=secret123");
+			expect(result.sanitized).toBe("ENV CONNECTION_STRING=server=localhost;key=secret123");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should handle values with double equals (base64 padding)", () => {
 			const input = "ENV API_KEY=base64encodedvalue==";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV API_KEY=********************"); // 20 chars
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV API_KEY=********************"); // 20 chars
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle database connection string with embedded equals", () => {
 			const input = "ENV DB_SECRET=postgresql://user:pass@host:5432/db?ssl=true";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV DB_SECRET=********************************************"); // 44 chars
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV DB_SECRET=********************************************"); // 44 chars
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should handle multiple key-value pairs in single ENV (only first is processed)", () => {
 			// Note: Current implementation only processes first key-value pair per ENV line
 			// This documents the current behavior - Docker allows multiple pairs but regex only captures first
 			const input = "ENV API_KEY=secret123 PORT=8080 NODE_ENV=production";
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 			// Current behavior: treats everything after first = as the value (including spaces)
-			expect(output).toBe("ENV API_KEY=***************************************"); // 39 chars
+			expect(result.sanitized).toBe("ENV API_KEY=***************************************"); // 39 chars
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 
 		it("should not mask non-sensitive vars in multi-pair ENV format", () => {
 			const input = "ENV PORT=8080 DEBUG=true NODE_ENV=production";
-			const output = sanitizeDockerfile(input);
+			const result = sanitizeDockerfile(input);
 			// Since PORT is not sensitive, entire line should be preserved
-			expect(output).toBe("ENV PORT=8080 DEBUG=true NODE_ENV=production");
+			expect(result.sanitized).toBe("ENV PORT=8080 DEBUG=true NODE_ENV=production");
+			expect(result.hasSensitiveValues).toBe(false);
 		});
 
 		it("should handle mixed sensitive and non-sensitive in multi-pair format", () => {
 			// When the first variable in a multi-pair ENV is sensitive, everything gets masked
 			const input = "ENV SECRET=value1 PORT=8080 DEBUG=true";
-			const output = sanitizeDockerfile(input);
-			expect(output).toBe("ENV SECRET=***************************"); // 27 chars
+			const result = sanitizeDockerfile(input);
+			expect(result.sanitized).toBe("ENV SECRET=***************************"); // 27 chars
+			expect(result.hasSensitiveValues).toBe(true);
 		});
 	});
 });

--- a/src/components/collapsibles/docker-image.ts
+++ b/src/components/collapsibles/docker-image.ts
@@ -7,24 +7,21 @@
  * Preserves non-sensitive variables like NODE_ENV, PORT, etc.
  *
  * @param dockerfile - The original Dockerfile content
- * @returns The sanitized Dockerfile with masked sensitive values
+ * @returns Object containing the sanitized Dockerfile and a boolean indicating if sensitive values were found
  *
  * @example
  * // Input:
- * ENV OPENAI_API_KEY=sk-abc123def456
- * ENV NODE_ENV=production
- * ENV DATABASE_SECRET=my-secret
+@@ -17,10 +17,10 @@
  * ENV PORT=3000
  *
  * // Output (sanitized for display):
- * ENV OPENAI_API_KEY=****************
+ * { sanitized: `ENV OPENAI_API_KEY=****************
  * ENV NODE_ENV=production
  * ENV DATABASE_SECRET=*********
- * ENV PORT=3000
+ * ENV PORT=3000`, hasSensitiveValues: true }
  */
 
 const envPattern = /^(\s*ENV\s+)([A-Z_][A-Z0-9_]*)(\s*=\s*|\s+)(.+?)(\s*\\?\s*)$/gim;
-
 const sensitiveSuffixes = [
 	"KEY",
 	"SECRET",
@@ -32,41 +29,49 @@ const sensitiveSuffixes = [
 	"PASSWORD",
 	"PASS",
 	"PWD",
-	"API_KEY",
-	"ACCESS_KEY",
-	"SECRET_KEY",
-	"PRIVATE_KEY",
-	"AUTH_TOKEN",
-	"BEARER_TOKEN",
 	"CREDENTIALS",
 	"CREDS"
 ];
 
-export function sanitizeDockerfile(dockerfile: string): string {
-	return dockerfile.replace(envPattern, (match, envPrefix, varName, separator, value, trailing) => {
-		const isSensitive = sensitiveSuffixes.some((suffix) => varName.toUpperCase().endsWith(suffix));
+export function sanitizeDockerfile(dockerfile: string): {
+	sanitized: string;
+	hasSensitiveValues: boolean;
+} {
+	let hasSensitiveValues = false;
 
-		if (!isSensitive) {
-			return match; // Keep non-sensitive variables as-is
+	const sanitized = dockerfile.replace(
+		envPattern,
+		(match, envPrefix, varName, separator, value, trailing) => {
+			const isSensitive = sensitiveSuffixes.some((suffix) =>
+				varName.toUpperCase().endsWith(suffix)
+			);
+
+			if (!isSensitive) {
+				return match; // Keep non-sensitive variables as-is
+			}
+
+			hasSensitiveValues = true;
+
+			// Trim the value to get accurate length (remove leading/trailing whitespace and quotes)
+			const trimmedValue = value.trim();
+			const valueLength = trimmedValue.length;
+
+			// Remove quotes if present to count the actual value length
+			let actualValueLength = valueLength;
+			if (
+				(trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
+				(trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
+			) {
+				actualValueLength = Math.max(0, valueLength - 2);
+			}
+
+			// Generate stars matching the actual value length
+			const stars = "*".repeat(Math.max(1, actualValueLength));
+
+			// Reconstruct the ENV statement with masked value
+			return `${envPrefix}${varName}${separator}${stars}${trailing}`;
 		}
+	);
 
-		// Trim the value to get accurate length (remove leading/trailing whitespace and quotes)
-		const trimmedValue = value.trim();
-		const valueLength = trimmedValue.length;
-
-		// Remove quotes if present to count the actual value length
-		let actualValueLength = valueLength;
-		if (
-			(trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
-			(trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
-		) {
-			actualValueLength = Math.max(0, valueLength - 2);
-		}
-
-		// Generate stars matching the actual value length
-		const stars = "*".repeat(Math.max(1, actualValueLength));
-
-		// Reconstruct the ENV statement with masked value
-		return `${envPrefix}${varName}${separator}${stars}${trailing}`;
-	});
+	return { sanitized, hasSensitiveValues };
 }

--- a/src/components/collapsibles/dockerfile-snippet.tsx
+++ b/src/components/collapsibles/dockerfile-snippet.tsx
@@ -1,0 +1,36 @@
+import { Codesnippet } from "@/components/CodeSnippet";
+import { sanitizeDockerfile } from "./docker-image";
+import { InfoBox } from "../Infobox";
+
+export function DockerfileSnippet({ dockerfile }: { dockerfile: string }) {
+	const dockerfileResult = sanitizeDockerfile(dockerfile);
+
+	return (
+		<div className="mt-5 space-y-2">
+			<p className="text-theme-text-secondary">Dockerfile</p>
+
+			{dockerfileResult.hasSensitiveValues && (
+				<InfoBox className="border-warning-300 bg-warning-50" intent="warning">
+					<strong>Security Notice:</strong> Sensitive environment variables detected in the
+					Dockerfile. Please use secure secret management instead of hardcoding sensitive values.{" "}
+					<a
+						href="https://docs.zenml.io/concepts/environment-variables"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="underline hover:text-warning-700"
+					>
+						Learn more about environment variables
+					</a>
+				</InfoBox>
+			)}
+			<Codesnippet
+				language="dockerfile"
+				highlightCode
+				fullWidth
+				wrap
+				code={dockerfileResult.sanitized}
+				copyCode={dockerfile}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
Before, we just redacted sensitive values from the dockerfile display, now there is a new warning, linking to documentation on how to properly handle sensivie values

<img width="2382" height="1720" alt="grafik" src="https://github.com/user-attachments/assets/facf190a-4491-4770-91c4-d86d30f41f31" />
