### PR TITLE
Add Hint when creating a stack manually

### DIFF
--- a/src/app/stacks/create/manual/TypeOverview.tsx
+++ b/src/app/stacks/create/manual/TypeOverview.tsx
@@ -107,6 +107,9 @@ function StackName() {
 				placeholder="zenml-stack"
 				{...register("stackName")}
 			/>
+			<p className="text-text-xs text-theme-text-secondary">
+				The stack name must be unique and cannot match an existing stack.
+			</p>
 			{errors.stackName && (
 				<p className="text-text-xs text-red-500">{errors.stackName.message?.toString()}</p>
 			)}


### PR DESCRIPTION
Adding the hint, that the stackname needs to be unique, when creating a stack manually

<img width="711" height="426" alt="grafik" src="https://github.com/user-attachments/assets/c117b524-2eec-4815-a91b-902e28ec2da2" />
