### PR TITLE
Adjust node-selectable-area

### DIFF
--- a/src/components/dag-visualizer/BaseNode.tsx
+++ b/src/components/dag-visualizer/BaseNode.tsx
@@ -9,6 +9,7 @@ export function BaseNode({ children }: PropsWithChildren) {
 				type="target"
 				position={Position.Top}
 			/>
+			{/* Disable pointer events on node container, re-enable on interactive children */}
 			<div className="flex w-[300px] items-center justify-center [&>*]:pointer-events-auto">
 				{children}
 			</div>

--- a/src/components/dag-visualizer/layout.ts
+++ b/src/components/dag-visualizer/layout.ts
@@ -87,6 +87,8 @@ export async function getLayoutedItems(
 		return {
 			...node,
 			style: {
+				// Disable pointer events on node container to prevent false selections
+				// Interactive children re-enable events via BaseNode's [&>*]:pointer-events-auto
 				pointerEvents: "none"
 			},
 			position: {


### PR DESCRIPTION
Before, a node inside the DAG could be marked as selected even though it wasn't hovering the button that actually opens the Panels. This PR introduced a fix for it.