### PR TITLE
Reduce verbosity of testing suggestions in AI reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -127,11 +127,11 @@ jobs:
               - If component APIs changed, check for updates to JSDoc comments or usage examples.
               - If new environment variables added, ensure .env.example is updated.
               - If OpenAPI types changed (src/types/core.ts), verify it was generated not hand-edited.
-            - Testing requirements:
-              - Unit tests (*.spec.ts) for new utilities in src/lib/
-              - E2E tests (e2e-tests/) for new user flows
-              - Suggest test coverage for critical business logic
-              - Verify test commands: pnpm test:unit, pnpm test:e2e, pnpm lint, pnpm build
+            - Testing guidance (keep concise—avoid verbose or generic suggestions):
+              - Only suggest tests directly relevant to the specific changes in this PR
+              - Briefly note if new utilities in src/lib/ lack a *.spec.ts file
+              - For UI changes, suggest 1-2 specific manual testing steps the author can perform
+              - Do NOT suggest comprehensive test suites or generic test patterns unrelated to the PR scope
             - If migration or breaking changes are introduced, recommend adding explicit notes.
             
             Review Format:

--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -126,7 +126,10 @@ jobs:
             Documentation & Testing:
             - Cross-check docs (README, CLAUDE.md, AGENTS.md) when user flows/components change.
             - Confirm env vars and OpenAPI types are updated where applicable.
-            - Recommend test coverage (unit/e2e) for critical flows.
+            - Testing (keep concise—avoid verbose or generic suggestions):
+              * Only suggest tests directly relevant to the specific changes in this PR
+              * For UI changes, suggest 1-2 specific manual testing steps
+              * Do NOT recommend comprehensive test suites or patterns unrelated to the PR scope
 
             Output Instructions:
             - Start with a summary of what the PR achieves.


### PR DESCRIPTION
## Summary
- Updates Claude Code and Codex review prompts to produce more focused, less verbose testing suggestions
- Testing feedback now emphasizes being laser-focused on the specific PR changes rather than suggesting generic or comprehensive test suites
- Manual testing suggestions are retained (within reason) as they provide practical, actionable value for reviewers

## Changes
- **claude-code-review.yml**: Replaced generic "Testing requirements" section with focused "Testing guidance" that explicitly discourages verbose suggestions
- **codex-comment.yml**: Added similar concise testing guidance to the Documentation & Testing section