### PR TITLE
Correct Claude trigger pattern and improve Codex post-comment reliability

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/claude /full-review')
+      contains(github.event.comment.body, '@claude /full-review')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,10 +36,10 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude') && !contains(github.event.comment.body, '/full-review')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/claude') && !contains(github.event.comment.body, '/full-review')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/claude') && !contains(github.event.review.body, '/full-review')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '/claude') || contains(github.event.issue.title, '/claude')))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/full-review')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/full-review')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '/full-review')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -142,28 +142,33 @@ jobs:
     name: Post Codex reply
     runs-on: ubuntu-latest
     needs: run-codex
-    if: |
-      needs.run-codex.result == 'success' &&
-      needs.run-codex.outputs.final_message != ''
+    if: always() && needs.run-codex.result == 'success'
     permissions:
       issues: write
       pull-requests: write
     steps:
-      - name: Reply with Codex output
-        uses: actions/github-script@v7
+      - name: Debug outputs
+        run: |
+          echo "Final message length: ${#FINAL_MESSAGE}"
+          echo "Issue number: ${{ github.event.issue.number }}"
         env:
-          CODEX_FINAL_MESSAGE: ${{ needs.run-codex.outputs.final_message }}
+          FINAL_MESSAGE: ${{ needs.run-codex.outputs.final_message }}
+      - name: Reply with Codex output
+        if: needs.run-codex.outputs.final_message
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const body = process.env.CODEX_FINAL_MESSAGE;
-            if (!body) {
+            const body = `${{ needs.run-codex.outputs.final_message }}`;
+            if (!body || body.trim() === '') {
               core.info('No Codex output to post.');
               return;
             }
+            console.log('Posting comment with length:', body.length);
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: ${{ github.event.issue.number }},
               body
             });
+            console.log('Comment posted successfully');


### PR DESCRIPTION
## Summary

Based on learnings from testing AI agent workflows in a fresh repository, this PR fixes critical issues with the Claude and Codex GitHub Actions integrations:

**Claude workflows (`claude.yml`, `claude-code-review.yml`):**
- ✅ Replace `/claude` with `@claude` in all trigger conditions - the Claude Code Action uses tag mode and expects `@claude` mentions
- ✅ Update `@claude /full-review` pattern for full code review workflow

**Codex workflow (`codex-comment.yml`):**
- ✅ Fix post-comment job reliability using `always() && ... == 'success'` pattern
- ✅ Move empty string check from job level to step level
- ✅ Use template literals instead of environment variables for multiline message handling
- ✅ Use explicit `${{ github.event.issue.number }}` reference
- ✅ Add debug step for easier troubleshooting

## Test Commands

After merging, test with:

**Claude:**
```
@claude Say hello and confirm you're working!
```

**Codex:**
```
/codex Say hello and confirm you're working!
```

cc @Cahllagerfeld