### PR TITLE
Add workflow to require release label on PRs

### DIFF
--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -1,0 +1,24 @@
+# Requires PRs to have either 'release-notes' or 'no-release-notes' label
+# This ensures release notes are considered for every PR before merging.
+# The check is enforced via branch protection rules on staging.
+name: Require Release Label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check-label:
+    if: github.repository == 'zenml-io/zenml-dashboard'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for release label
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "release-notes, no-release-notes"
+          message: |
+            This PR is missing a release label. Please add one of:
+            - `release-notes` - if this PR has user-facing changes that should appear in the changelog
+            - `no-release-notes` - if this is an internal change (refactoring, tests, CI, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,3 +322,17 @@ When using AI tools with this codebase:
 3. Style with Tailwind CSS utility classes
 4. Export from component file (avoid barrel exports)
 5. Prefer focused components, forward transient props where helpful, and remove `console.log` statements once debugging is complete.
+
+## Git Conventions
+
+### PR Titles
+
+- Use plain, descriptive titles without conventional commit prefixes (no `feat:`, `fix:`, `ci:`, etc.)
+- Good: "Add workflow to require release label on PRs"
+- Bad: "ci: add workflow to require release label on PRs"
+
+### Labels
+
+All PRs should have one of the following release labels:
+- `release-notes` - for user-facing changes that should appear in the changelog
+- `no-release-notes` - for internal changes (refactoring, tests, CI, etc.)


### PR DESCRIPTION
## Summary
- Adds a GitHub workflow that checks for `release-notes` or `no-release-notes` labels on all PRs
- This ensures release notes are considered for every PR before merging to `staging`
- The check can be enforced via branch protection rules
- Also documents git conventions in CLAUDE.md (PR title format and required labels)

## Branch Protection Setup

After merging, apply branch protection rules to `staging` with:

```bash
gh api -X PUT /repos/zenml-io/zenml-dashboard/branches/staging/protection \
  --input - <<'PROTECTION'
{
  "required_pull_request_reviews": {
    "required_approving_review_count": 1,
    "dismiss_stale_reviews": false,
    "require_code_owner_reviews": false
  },
  "required_status_checks": {
    "strict": false,
    "contexts": ["check-label"]
  },
  "enforce_admins": true,
  "restrictions": null,
  "allow_force_pushes": true,
  "allow_deletions": false,
  "block_creations": true
}
PROTECTION
```

## Test plan
- [x] Workflow file syntax is valid
- [ ] After merge, verify workflow runs on new PRs
- [ ] Apply branch protection and verify the check blocks merging without labels