### PR TITLE
Add changelog notification workflow

### DIFF
--- a/.github/workflows/notify-changelog.yml
+++ b/.github/workflows/notify-changelog.yml
@@ -1,0 +1,62 @@
+name: Notify Changelog Repo
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g., 0.92.0)'
+        required: true
+        type: string
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # Only trigger for non-prerelease, non-draft releases (auto) or manual dispatch
+    if: github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !github.event.release.draft)
+    steps:
+      - name: Get release info
+        id: release_info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let release;
+            if (context.eventName === 'workflow_dispatch') {
+              // Manual trigger: fetch release by tag
+              const tag = '${{ inputs.release_tag }}';
+              release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag
+              });
+              release = release.data;
+            } else {
+              // Automatic trigger: use event payload
+              release = context.payload.release;
+            }
+            
+            core.setOutput('tag', release.tag_name);
+            core.setOutput('name', release.name || release.tag_name);
+            core.setOutput('url', release.html_url);
+            core.setOutput('body', JSON.stringify(release.body || ''));
+            core.setOutput('published_at', release.published_at);
+            core.setOutput('prerelease', release.prerelease);
+
+      - name: Send repository dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CHANGELOG_DISPATCH_TOKEN }}
+          repository: zenml-io/zenml-changelog
+          event-type: release-published
+          client-payload: |
+            {
+              "repo": "${{ github.repository }}",
+              "repo_name": "${{ github.event.repository.name }}",
+              "release_tag": "${{ steps.release_info.outputs.tag }}",
+              "release_name": "${{ steps.release_info.outputs.name }}",
+              "release_url": "${{ steps.release_info.outputs.url }}",
+              "release_body": ${{ steps.release_info.outputs.body }},
+              "published_at": "${{ steps.release_info.outputs.published_at }}",
+              "is_prerelease": ${{ steps.release_info.outputs.prerelease }}
+            }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that notifies `zenml-io/zenml-changelog` when releases are published
- Enables automated changelog generation from PRs with the `release-notes` label

## How It Works
1. When a release is published (non-draft, non-prerelease), this workflow triggers
2. It sends a `repository_dispatch` event to `zenml-io/zenml-changelog`
3. The changelog repo's automation fetches PRs and generates changelog entries

## Required Secret
This workflow requires `CHANGELOG_DISPATCH_TOKEN` to be configured (org-level or repo-level) with `repo` scope.

## Test plan
- [ ] Verify workflow file is at `.github/workflows/notify-changelog.yml`
- [ ] Verify YAML syntax is valid
- [ ] After merge: test with manual trigger using an existing release tag
- [ ] Verify `zenml-io/zenml-changelog` receives the dispatch event