### PR TITLE
Disable CodeRabbit automatic status message

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: "en"
 early_access: false
 reviews:
-  high_level_summary: true
+  high_level_summary: false
   poem: false
   review_status: false
   collapse_walkthrough: true


### PR DESCRIPTION
## Summary
- Disables CodeRabbit's automatic review status messages on PRs
- Disables high-level summary comments
- Keeps auto_review disabled to reduce PR noise

## Test plan
- [ ] Verify CodeRabbit no longer posts automatic status messages on new PRs