### PR TITLE
Fix Styling for Highlight Modal

### DIFF
--- a/src/components/announcements/announcement-highlight/index.tsx
+++ b/src/components/announcements/announcement-highlight/index.tsx
@@ -53,7 +53,7 @@ export function AnnouncementHighlight() {
 
 	return (
 		<Dialog open={open} onOpenChange={handleChange}>
-			<DialogContent className="flex max-w-[600px] flex-col overflow-hidden">
+			<DialogContent className="flex max-h-screen max-w-[600px] flex-col overflow-hidden overflow-y-auto">
 				{currentItem.video_url ? (
 					<AnnouncementVideo videoUrl={currentItem.video_url} />
 				) : (
@@ -81,7 +81,7 @@ export function AnnouncementHighlight() {
 							</ul>
 						</div>
 						<Markdown
-							className="prose max-h-[200px] overflow-y-auto text-theme-text-secondary"
+							className="prose text-theme-text-secondary"
 							markdown={currentItem.description}
 						/>
 					</div>

--- a/src/components/announcements/announcement-image.tsx
+++ b/src/components/announcements/announcement-image.tsx
@@ -15,7 +15,7 @@ export function AnnouncementImage({ imageUrl, title, className }: Props) {
 			loading="lazy"
 			src={src}
 			alt={`Announcement image for ${title}`}
-			className={cn("aspect-video h-full w-full object-cover", className)}
+			className={cn("aspect-video h-full w-full shrink-0 object-cover", className)}
 		/>
 	);
 }

--- a/src/components/announcements/announcement-video.tsx
+++ b/src/components/announcements/announcement-video.tsx
@@ -9,7 +9,7 @@ export function AnnouncementVideo({ videoUrl, className }: Props) {
 	return (
 		<div className={cn("overflow-hidden", className)}>
 			<iframe
-				className="aspect-video w-full overflow-hidden"
+				className="aspect-video w-full shrink-0 overflow-hidden"
 				src={videoUrl}
 				title="YouTube video player"
 				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
Whenver there is a new changelog item that should be highlighted, the scroll-behavior of the content is clunky if the text is too long. This PR adds a max-height so it starts scrolling after a certain hight, so it doesnt block the entire screen