### PR TITLE
Fix changelog notifier not triggering on prerelease conversion

### DIFF
--- a/.github/workflows/notify-changelog.yml
+++ b/.github/workflows/notify-changelog.yml
@@ -2,11 +2,12 @@ name: Notify Changelog Repo
 
 on:
   release:
-    types: [published]
+    # 'published' fires on initial creation, 'released' fires when prerelease → full release
+    types: [published, released]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag (e.g., 0.92.0)'
+        description: 'Release tag (e.g., v0.92.0)'
         required: true
         type: string
 


### PR DESCRIPTION
## Summary
- Added `released` event type to trigger when prereleases are converted to full releases
- Fixed example tag in `workflow_dispatch` to show correct `v` prefix (e.g., `v0.92.0`)

## Problem
The release workflow creates releases as prereleases first (`prerelease: "true"` in `release.yml`), then they're manually converted to full releases. The notify-changelog workflow was only listening for `published` events, which:
1. Fire on initial creation (but get filtered by the prerelease check in the `if` condition)
2. Do NOT fire again when a prerelease is converted to a full release

## Solution
Added `released` event type which fires specifically when a prerelease is converted to a full release.

## Test plan
- [ ] Next release: verify workflow triggers automatically when prerelease is marked as full release