### PR TITLE
Add planning/review guidelines and style thrash prevention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,9 @@
 - Remove debug `console` statements before committing.
 
 ## Planning & Review (Agentic Work)
-- For non-trivial changes, start with a short Markdown plan/spec (scope, files to touch, existing patterns to reuse, acceptance criteria) and get Julian to review it before implementation.
+- For non-trivial changes, start with a short Markdown plan/spec (scope, files to touch, existing patterns to reuse, acceptance criteria) and get [@Cahllagerfeld](https://github.com/Cahllagerfeld) to review it before implementation.
 - **Avoid style thrash:** if you find yourself repeatedly nudging Tailwind/CSS to make something "look right" (especially across multiple commits), pause and reassess against the spec and existing design tokens/components.
-- Treat widespread or unrelated styling edits as a blocker: if a visual fix requires touching multiple unrelated components, adding arbitrary pixel constants, or layering overrides, stop and ask for an authoritative reference (screenshot/spec) or escalate to Julian rather than continuing to iterate.
+- Treat widespread or unrelated styling edits as a blocker: if a visual fix requires touching multiple unrelated components, adding arbitrary pixel constants, or layering overrides, stop and ask for an authoritative reference (screenshot/spec) or escalate to [@Cahllagerfeld](https://github.com/Cahllagerfeld) rather than continuing to iterate.
 - Prefer fixing the abstraction (token/variant/layout primitive) over local one-off overrides.
 
 ## Scope Guardrails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ When using AI tools with this codebase:
 3. Note that many patterns are shared with zenml-cloud-ui (check that repo for reference implementations)
 
 ### Plan & Review (Agentic Work)
-- For non-trivial changes, start with a short Markdown plan/spec (scope, files to touch, similar existing flows, acceptance criteria) and get Julian to review it before implementation.
+- For non-trivial changes, start with a short Markdown plan/spec (scope, files to touch, similar existing flows, acceptance criteria) and get [@Cahllagerfeld](https://github.com/Cahllagerfeld) to review it before implementation.
 - **Avoid style thrash:** do not fall into repeated "make it look right" loops of tiny Tailwind/CSS nudges. If you notice multiple iterations where the diff is mostly styling tweaks, stop and re-anchor to the plan and design tokens.
 - Ask for a single authoritative reference (screenshot/spec) and explicit acceptance criteria before continuing visual polish. Prefer correcting tokens/variants/layout primitives over adding scattered one-off overrides.
 - If a visual change seems to require touching unrelated components or adding arbitrary pixel constants, treat that as a sign the approach is wrong and escalate for human guidance instead of continuing to iterate blindly.


### PR DESCRIPTION
## Summary
- Add guidance for writing Markdown spec/plan before non-trivial changes
- Require Julian's review before implementation
- Add explicit warnings against style thrash during visual QA iterations
- Recommend using strong models for planning passes

These updates are based on learnings from recent agentic PRs to prevent common issues like scattered CSS tweaks and lack of upfront planning.

## Test plan
- [x] Review AGENTS.md changes
- [x] Review CLAUDE.md changes