### PR TITLE
Fix Codex workflow by removing invalid codex-args

### DIFF
--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -65,7 +65,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          codex-args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
           prompt: |
             You are Codex assisting on pull request #${{ github.event.issue.number }} in ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary

Removes the invalid `codex-args` line from the Codex GitHub Actions workflow. The `--allowed-tools` flag does not exist in `codex exec`, causing the workflow to fail with:

```
error: unexpected argument '--allowed-tools' found
```

## Changes

- Removed `codex-args: --allowed-tools "..."` from `.github/workflows/codex-comment.yml`

## Security

The workflow retains adequate security via:
- `permissions: contents: read` (cannot modify repo)
- `sandbox: workspace-write` (filesystem restrictions)  
- `safety-strategy: drop-sudo` (no sudo access)

## Test Plan

- [x] Verify workflow YAML is valid
- [ ] Trigger `/codex` comment on a test PR to confirm the workflow runs