### PR TITLE
fix: redirect to password field after Enter on username

### DIFF
--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -52,6 +52,14 @@ export function LoginForm() {
 		mutation.mutate({ username: data.username.trim(), password: data.password });
 	}
 
+	function handleUsernameKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+		// When user presses Enter on username field, focus the password field
+		if (e.key === "Enter") {
+			e.preventDefault();
+			document.getElementById(passwordId)?.focus();
+		}
+	}
+
 	return (
 		<form onSubmit={handleSubmit(login)} className="space-y-5">
 			<div className="space-y-2">
@@ -59,7 +67,12 @@ export function LoginForm() {
 					<label htmlFor={usernameId} className="text-text-sm">
 						Username
 					</label>
-					<Input {...register("username")} id={usernameId} className="w-full" />
+					<Input
+						{...register("username")}
+						id={usernameId}
+						className="w-full"
+						onKeyDown={handleUsernameKeyDown}
+					/>
 				</div>
 				<div className="space-y-0.5">
 					<label htmlFor={passwordId} className="text-text-sm">


### PR DESCRIPTION
## Summary
Improves login UX by focusing the password field when user presses Enter on the username field, instead of showing an error about missing password.

## Changes Made
- Added `onKeyDown` handler to username Input in LoginForm.tsx
- When Enter key is pressed, calls `preventDefault()` and focuses the password field

## Acceptance Criteria
- [x] User can tab from username to password using Enter key
- [x] No error shown for missing password when pressing Enter on username
- [x] Maintains existing form behavior