### PR TITLE
Supply chain hardening: pnpm cooldowns, pinned GH Actions, persist-credentials

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -22,10 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,9 +16,10 @@ jobs:
       is-team-member: ${{ steps.check.outputs.is-member }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Check if actor is team member
         id: check
         run: |
@@ -54,12 +55,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -20,9 +20,10 @@ jobs:
       is-team-member: ${{ steps.check.outputs.is-member }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Check if actor is on team
         id: check
         run: |
@@ -48,10 +49,11 @@ jobs:
       final_message: ${{ steps.codex.outputs.final-message }}
     steps:
       - name: Checkout PR merge commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.issue.number }}/merge
+          persist-credentials: false
       - name: Fetch base and head refs
         run: |
           git fetch --no-tags origin \
@@ -60,7 +62,7 @@ jobs:
             +refs/pull/${{ github.event.issue.number }}/merge
       - name: Run Codex
         id: codex
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
@@ -130,7 +132,7 @@ jobs:
           FINAL_MESSAGE: ${{ needs.run-codex.outputs.final_message }}
       - name: Reply with Codex output
         if: needs.run-codex.outputs.final_message
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,8 +9,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -19,7 +21,7 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
         run: pnpm exec playwright test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Get the version from the github tag ref
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: latest
 
@@ -37,7 +37,7 @@ jobs:
           VITE_REO_KEY: ${{ secrets.REO_KEY }}
 
       - name: Generate Changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        uses: heinrichreimer/github-changelog-generator-action@04f64206d10b4f9c882da8157ffc3dfa6ce66b3e # v2.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pullRequests: "false"
@@ -52,7 +52,7 @@ jobs:
           sha256sum -b zenml-dashboard.tar.gz > zenml-dashboard.tar.gz.sha256
 
       - name: Release to GitHub
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: |
             zenml-dashboard.tar.gz

--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for release label
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           # Only process PRs, not issues
           days-before-stale: -1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,15 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: latest
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,22 @@
+# Supply chain security settings (pnpm v10+)
+# See: https://pnpm.io/supply-chain-security
+
+# Allowlist packages that can run lifecycle scripts (postinstall, etc.)
+# pnpm v10 disables these by default; only esbuild needs its postinstall
+# to download the platform-specific binary.
+onlyBuiltDependencies:
+  - "@swc/core"
+  - esbuild
+
+# Ignore packages published less than 7 days ago (10080 minutes).
+# This protects against supply chain attacks where a compromised maintainer
+# publishes a malicious version — most get detected and yanked within days.
+minimumReleaseAge: 10080
+
+# Block transitive dependencies from using git repos or tarball URLs.
+# These bypass the registry and can't be audited by release-age checks.
+blockExoticSubdeps: true
+
+# Block a new version if its trust level (e.g., provenance, signing) is
+# weaker than the previous release. Catches credential compromise scenarios.
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

- **pnpm-workspace.yaml**: Adds `minimumReleaseAge` (7-day cooldown), `blockExoticSubdeps`, `trustPolicy: no-downgrade`, and `onlyBuiltDependencies` allowlist (`esbuild`, `@swc/core`)
- **GitHub Actions**: Pins all 11 third-party action references across 8 workflow files to full-length commit SHAs with version comments for readability
- **persist-credentials**: Sets `persist-credentials: false` on `actions/checkout` steps where the `GITHUB_TOKEN` is not needed downstream (all except the release workflow)

## Why

Supply chain attacks on npm packages and GitHub Actions are increasingly common. The [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-compromise) (March 2025) affected 23,000+ repos via mutable tag poisoning — exactly the pattern we were using.

**pnpm cooldowns**: 8 of 10 recent supply chain attacks had windows of opportunity under a week. A 7-day `minimumReleaseAge` means pnpm ignores packages published in the last 7 days, giving the community time to detect and yank compromised versions before they reach our CI.

**SHA pinning**: Git tags are mutable — an attacker who compromises a maintainer can move `v5` to point at malicious code. A full SHA is immutable.

**persist-credentials**: Prevents `GITHUB_TOKEN` from leaking into later workflow steps that don't need it.

## Follow-up

Dependabot configuration is tracked separately in #1030 — it adds a second layer (delaying update PRs) on top of the pnpm-level cooldown (blocking during install).

## Test plan

- [x] `pnpm install --frozen-lockfile` passes cleanly (no warnings about ignored build scripts)
- [x] `pnpm build` completes successfully
- [ ] CI workflows should pass unchanged (SHA-pinned refs resolve to the same code as the tags they replace)