### PR TITLE
Harden CI workflows against script injection and auth bypass

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,14 +22,15 @@ jobs:
           persist-credentials: false
       - name: Check if actor is team member
         id: check
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          ACTOR="${{ github.actor }}"
-          if grep -q "@${ACTOR}" .github/teams.yml; then
-            echo "is-member=true" >> $GITHUB_OUTPUT
-            echo "✅ $ACTOR is a team member"
+          if grep -qF "'@${ACTOR}'" .github/teams.yml; then
+            echo "is-member=true" >> "$GITHUB_OUTPUT"
+            echo "✅ ${ACTOR} is a team member"
           else
-            echo "is-member=false" >> $GITHUB_OUTPUT
-            echo "❌ $ACTOR is not a team member"
+            echo "is-member=false" >> "$GITHUB_OUTPUT"
+            echo "❌ ${ACTOR} is not a team member"
           fi
   claude:
     needs: check-team-member

--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -26,14 +26,15 @@ jobs:
           persist-credentials: false
       - name: Check if actor is on team
         id: check
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          ACTOR="${{ github.actor }}"
-          if grep -q "@${ACTOR}" .github/teams.yml; then
+          if grep -qF "'@${ACTOR}'" .github/teams.yml; then
             echo "is-member=true" >> "$GITHUB_OUTPUT"
-            echo "✅ $ACTOR is a team member"
+            echo "✅ ${ACTOR} is a team member"
           else
             echo "is-member=false" >> "$GITHUB_OUTPUT"
-            echo "❌ $ACTOR is not a team member"
+            echo "❌ ${ACTOR} is not a team member"
           fi
 
   run-codex:
@@ -133,10 +134,13 @@ jobs:
       - name: Reply with Codex output
         if: needs.run-codex.outputs.final_message
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          FINAL_MESSAGE: ${{ needs.run-codex.outputs.final_message }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const body = `${{ needs.run-codex.outputs.final_message }}`;
+            const body = process.env.FINAL_MESSAGE;
             if (!body || body.trim() === '') {
               core.info('No Codex output to post.');
               return;
@@ -145,7 +149,7 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ github.event.issue.number }},
+              issue_number: parseInt(process.env.ISSUE_NUMBER, 10),
               body
             });
             console.log('Comment posted successfully');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,18 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Get the version from the github tag ref
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
## Summary

Hardens three GitHub Actions workflows against attack patterns from the [hackerbot-claw campaign](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation), which achieved RCE and token theft across major repos (Trivy, awesome-go, DataDog).

**Our repo is not compromised** — no `pull_request_target` workflows, all actions SHA-pinned. But the audit found these hardening gaps:

- **Script injection in `codex-comment.yml`**: `${{ needs.run-codex.outputs.final_message }}` was interpolated directly into a JS template literal in `github-script`. A crafted Codex output containing backticks could execute arbitrary JavaScript with `issues: write` + `pull-requests: write` permissions. Fixed by reading from `process.env.FINAL_MESSAGE` instead.

- **Weak team member check in `claude.yml` and `codex-comment.yml`**: `grep -q "@${ACTOR}"` was a substring match — a GitHub user named `alex` would match team member `@alex-zenml`. Fixed with quote-anchored fixed-string grep (`grep -qF "'@${ACTOR}'"`) that matches the exact `'@username'` format in `teams.yml`. Also moved `${{ github.actor }}` from inline interpolation to `env:` block.

- **`release.yml` hardening**: Added `persist-credentials: false` to checkout, replaced deprecated `::set-output` with `$GITHUB_OUTPUT`, added explicit least-privilege permissions (`contents: write`, `issues: read`).

Related: #1032, #1033

## Test plan

- [ ] Verify team member check still works: have a team member comment `@claude` or `/codex` on this PR
- [ ] Verify non-team-members are still rejected (check workflow run logs)
- [ ] Release workflow changes verified on next tag push (set-output replacement, persist-credentials)
- [ ] Grep anchoring verified locally: `grep -qF "'@alex'" .github/teams.yml` returns no match, `grep -qF "'@alex-zenml'" .github/teams.yml` matches correctly