### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "no-release-notes"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -20,6 +20,8 @@ jobs:
   check:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   check-team-member:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       is-team-member: ${{ steps.check.outputs.is-member }}
     steps:

--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -12,6 +12,8 @@ jobs:
   check-team-member:
     name: Validate Codex commenter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: |
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/codex') &&
@@ -46,6 +48,8 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true'
     permissions:
       contents: read
+      pull-requests: read
+      issues: read
     outputs:
       final_message: ${{ steps.codex.outputs.final-message }}
     steps:
@@ -56,11 +60,31 @@ jobs:
           ref: refs/pull/${{ github.event.issue.number }}/merge
           persist-credentials: false
       - name: Fetch base and head refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          set -euo pipefail
+
+          case "$PR_NUMBER" in
+            ""|*[!0-9]*)
+              echo "Invalid PR number: $PR_NUMBER" >&2
+              exit 1
+              ;;
+          esac
+
+          BASE_REF="$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')"
+          if [ -z "$BASE_REF" ]; then
+            echo "Unable to resolve base ref for PR #$PR_NUMBER" >&2
+            exit 1
+          fi
+
+          git check-ref-format --branch "$BASE_REF" >/dev/null
+
           git fetch --no-tags origin \
-            ${{ github.event.issue.pull_request.base.ref }} \
-            +refs/pull/${{ github.event.issue.number }}/head \
-            +refs/pull/${{ github.event.issue.number }}/merge
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head" \
+            "+refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge"
       - name: Run Codex
         id: codex
         uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1
@@ -123,7 +147,6 @@ jobs:
     if: always() && needs.run-codex.result == 'success'
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Debug outputs
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,8 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -57,7 +58,7 @@ jobs:
           sha256sum -b zenml-dashboard.tar.gz > zenml-dashboard.tar.gz.sha256
 
       - name: Release to GitHub
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1 # zizmor: ignore[superfluous-actions] preserves existing release behavior; refactoring to gh CLI is out of scope.
         with:
           files: |
             zenml-dashboard.tar.gz

--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -11,6 +11,9 @@ jobs:
   check-label:
     if: github.repository == 'zenml-io/zenml-dashboard'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: read
     steps:
       - name: Check for release label
         uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: Audit GitHub Actions
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+      - future
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Audit workflows
+        run: uvx zizmor .github

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - main
-      - future
+      - staging
     paths:
       - ".github/**"
 


### PR DESCRIPTION
## Summary

- add GitHub Actions-only Dependabot updates with cooldown settings
- add explicit least-privilege `permissions:` blocks to workflows/jobs that previously inherited repository defaults
- harden the Codex workflow's PR ref fetching against shell template-injection patterns
- add a blocking `zizmor` workflow audit for `.github/**` changes
- disable automatic `actions/setup-node` package-manager caching in the release workflow and narrowly ignore the out-of-scope release-action refactor suggestion

## Why

This continues the workflow supply-chain hardening work by keeping action SHAs updateable, limiting `GITHUB_TOKEN` blast radius, and adding an automated guardrail for future workflow changes.

Closes #1030
Closes #1032
Closes #1033

## Verification

- `uvx zizmor .github`
- `git diff --check`
- confirmed `.github/dependabot.yml` only configures `package-ecosystem: "github-actions"`
- confirmed the `no-release-notes` label exists for Dependabot PRs

## Screenshots

Not applicable — CI/config-only change.
