### PR TITLE
Drop unsupported `semver-*-days` keys from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
       timezone: "Europe/Amsterdam"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
     open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## Summary

Removes the three `semver-*-days` keys from the `cooldown` block in `.github/dependabot.yml`, keeping only `default-days: 7`.

## Why

Dependabot's config validation fails with:

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

Those keys were added in #1039 as part of supply-chain hardening, but GitHub Actions versions aren't true semver (tags like `@v4`, majors-only aliases, or full SHAs are all valid), so Dependabot explicitly rejects semver-aware cooldown keys for that ecosystem. The failing check has been appearing on every PR that has since merged `staging`, e.g. #1038.

## Security posture

Keeping `default-days: 7` preserves a meaningful cooldown window aligned with published best practice:

- [yossarian.net — "We should all be using dependency cooldowns"](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) empirically shows a 7-day cooldown would have blocked **8 of 10** historical supply-chain attacks. Their published example uses exactly `default-days: 7` for `package-ecosystem: github-actions`.
- Existing defense-in-depth from #1039 (SHA pinning, the `zizmor` audit, explicit least-privilege `permissions:` blocks) continues to cover the cases cooldown alone cannot.

The previous `semver-major-days: 30` was a belt-and-braces measure, but since Dependabot cannot classify Actions bumps as major/minor/patch in the first place, that knob was never going to fire — this PR just removes the misleading dead config.

## Verification

- `.github/dependabot.yml` now parses under Dependabot's schema (no unsupported keys for the `github-actions` ecosystem).
- Confirmed the remaining config still only scopes to `github-actions`, retains `open-pull-requests-limit: 5`, the `ci` commit prefix, and the `no-release-notes` label for Dependabot PRs.

## Test plan

- [ ] Dependabot `.github/dependabot.yml` check passes green on this PR
- [ ] After merge, the `.github/dependabot.yml` check also goes green on #1038 (and any other open PRs) once they pick up `staging`