### PR TITLE
Move pnpm overrides to pnpm-workspace.yaml and pin pnpm to v10

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,8 +17,12 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
+      - name: Install pnpm
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Essential Commands
 
 ```bash
-pnpm install          # Install dependencies (uses pnpm, not yarn!)
+pnpm install          # Install dependencies — requires pnpm v10 (v11 not yet supported)
 pnpm dev             # Start development server (default port 5173)
 pnpm build           # Build for production (tsc + vite build)
 pnpm lint            # Run ESLint

--- a/README.md
+++ b/README.md
@@ -52,11 +52,17 @@ To get started with the ZenML Dashboard, follow these steps:
 
 2. **Install Pnpm:**
 
-   - The project uses Pnpm as the package manager. Install it with:
+   - The project uses pnpm v10 as the package manager. pnpm v11 is not yet supported
+     (it introduced trust-downgrade checks that conflict with some dependencies).
+     Install it with:
 
      ```bash
-     npm install -g pnpm
+     npm install -g pnpm@10
      ```
+
+     Alternatively, if you use [corepack](https://nodejs.org/api/corepack.html), run
+     `corepack enable` and it will pick up the required version from `package.json`
+     automatically.
 
 3. **Install Dependencies:**
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
+	"packageManager": "pnpm@10.33.4",
 	"scripts": {
 		"build": "tsc && vite build",
 		"dev": "vite",
@@ -92,10 +93,5 @@
 		"vite-plugin-bundle-prefetch": "^0.0.4",
 		"vite-plugin-svgr": "^4.5.0",
 		"vitest": "^4.1.2"
-	},
-	"pnpm": {
-		"overrides": {
-			"dompurify": "^3.4.0"
-		}
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,9 @@ blockExoticSubdeps: true
 # Block a new version if its trust level (e.g., provenance, signing) is
 # weaker than the previous release. Catches credential compromise scenarios.
 trustPolicy: no-downgrade
+
+# Override transitive dependency versions.
+# Moved here from the "pnpm" field in package.json, which pnpm v10+ no longer reads
+# (it silently ignores overrides placed there and emits a [WARN] on every install).
+overrides:
+  dompurify: "^3.4.0"


### PR DESCRIPTION
## Summary

- Moves the `dompurify` override from the `"pnpm"` field in `package.json` to `pnpm-workspace.yaml`, which is the correct location in pnpm v10+ (the old field is silently ignored and emits a `[WARN]` on every install)
- Adds `"packageManager": "pnpm@10.33.4"` to `package.json` so corepack and compatible tooling enforce the required version automatically
- Documents the pnpm v10 requirement in `README.md` and `CLAUDE.md` — previously the README linked to an unversioned `npm install -g pnpm` that would land developers on pnpm v11, which is not yet supported
- Pins `playwright.yml` to pnpm v10 via `pnpm/action-setup` (it was using an unversioned `npm install -g pnpm`, inconsistent with `release.yml` and `unit-tests.yml`)

No behavioral changes — this is purely a cleanup and documentation pass.

A companion PR for pnpm v11 support will follow once the project is ready to upgrade.

## Test plan

- [x] `pnpm install` completes clean with no warnings or errors (pnpm v10.33.4)
- [x] `pnpm build` passes
- [x] CI passes