### PR TITLE
Table scrolling and consistent content max-width

### DIFF
--- a/src/app/components/StackComponentList.tsx
+++ b/src/app/components/StackComponentList.tsx
@@ -64,7 +64,7 @@ export function StackComponentList({ fixedQueryParams, displayCreateComponent = 
 				</div>
 
 				<div className="flex flex-col items-center gap-5">
-					<div className="w-full">
+					<div className="w-full overflow-x-auto">
 						{data ? (
 							<DataTable
 								getRowId={(row) => row.id}

--- a/src/app/deployments/[deploymentId]/_layout/header/index.tsx
+++ b/src/app/deployments/[deploymentId]/_layout/header/index.tsx
@@ -4,7 +4,7 @@ import { DeploymentDetailTabs } from "./tabs";
 export function DeploymentDetailHeader({ deploymentId }: { deploymentId: string }) {
 	return (
 		<section className="shrink-0 overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="space-y-1 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-screen-xl space-y-1 px-5 pt-5 lg:px-[80px]">
 				<DeploymentDetailHeaderInfo deploymentId={deploymentId} />
 				<DeploymentDetailTabs />
 			</div>

--- a/src/app/deployments/[deploymentId]/_layout/header/index.tsx
+++ b/src/app/deployments/[deploymentId]/_layout/header/index.tsx
@@ -4,7 +4,7 @@ import { DeploymentDetailTabs } from "./tabs";
 export function DeploymentDetailHeader({ deploymentId }: { deploymentId: string }) {
 	return (
 		<section className="shrink-0 overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="mx-auto w-full max-w-screen-xl space-y-1 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-[1440px] space-y-1 px-5 pt-5 lg:px-[80px]">
 				<DeploymentDetailHeaderInfo deploymentId={deploymentId} />
 				<DeploymentDetailTabs />
 			</div>

--- a/src/app/deployments/[deploymentId]/page.tsx
+++ b/src/app/deployments/[deploymentId]/page.tsx
@@ -7,7 +7,7 @@ import { DeploymentStackCollapsible } from "./_components/stack-collapsible";
 
 export default function DeploymentDetailPage() {
 	return (
-		<div className="mx-auto grid w-full max-w-screen-xl grid-cols-1 gap-5 p-5 lg:grid-cols-2 lg:px-[80px]">
+		<div className="mx-auto grid w-full max-w-[1440px] grid-cols-1 gap-5 p-5 lg:grid-cols-2 lg:px-[80px]">
 			<div className="space-y-5">
 				<EndpointCollapsible />
 				<DeploymentCodeCollapsible />

--- a/src/app/deployments/[deploymentId]/page.tsx
+++ b/src/app/deployments/[deploymentId]/page.tsx
@@ -7,7 +7,7 @@ import { DeploymentStackCollapsible } from "./_components/stack-collapsible";
 
 export default function DeploymentDetailPage() {
 	return (
-		<div className="grid grid-cols-1 gap-5 p-5 lg:grid-cols-2 lg:px-[80px]">
+		<div className="mx-auto grid w-full max-w-screen-xl grid-cols-1 gap-5 p-5 lg:grid-cols-2 lg:px-[80px]">
 			<div className="space-y-5">
 				<EndpointCollapsible />
 				<DeploymentCodeCollapsible />

--- a/src/app/deployments/[deploymentId]/runs/page.tsx
+++ b/src/app/deployments/[deploymentId]/runs/page.tsx
@@ -3,7 +3,7 @@ import { DeploymentRunsContent } from "./page.content";
 
 export default function DeploymentRunsPage() {
 	return (
-		<div className="mx-auto w-full max-w-screen-xl space-y-5 p-5 lg:px-[80px]">
+		<div className="mx-auto w-full max-w-[1440px] space-y-5 p-5 lg:px-[80px]">
 			<RunsSelectorContextProvider>
 				<DeploymentRunsContent />
 			</RunsSelectorContextProvider>

--- a/src/app/deployments/[deploymentId]/runs/page.tsx
+++ b/src/app/deployments/[deploymentId]/runs/page.tsx
@@ -3,7 +3,7 @@ import { DeploymentRunsContent } from "./page.content";
 
 export default function DeploymentRunsPage() {
 	return (
-		<div className="space-y-5 p-5 lg:px-[80px]">
+		<div className="mx-auto w-full max-w-screen-xl space-y-5 p-5 lg:px-[80px]">
 			<RunsSelectorContextProvider>
 				<DeploymentRunsContent />
 			</RunsSelectorContextProvider>

--- a/src/app/pipelines/[pipelineId]/_layout/header.tsx
+++ b/src/app/pipelines/[pipelineId]/_layout/header.tsx
@@ -3,7 +3,7 @@ import { PipelineDetailNameSection } from "./name-section";
 export function PipelineDetailHeader() {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="mx-auto w-full max-w-screen-xl space-y-1 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-[1440px] space-y-1 px-5 pt-5 lg:px-[80px]">
 				<PipelineDetailNameSection />
 				<PipelineDetailTabs />
 			</div>

--- a/src/app/pipelines/[pipelineId]/_layout/header.tsx
+++ b/src/app/pipelines/[pipelineId]/_layout/header.tsx
@@ -3,7 +3,7 @@ import { PipelineDetailNameSection } from "./name-section";
 export function PipelineDetailHeader() {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="space-y-1 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-screen-xl space-y-1 px-5 pt-5 lg:px-[80px]">
 				<PipelineDetailNameSection />
 				<PipelineDetailTabs />
 			</div>

--- a/src/app/pipelines/[pipelineId]/layout.tsx
+++ b/src/app/pipelines/[pipelineId]/layout.tsx
@@ -5,7 +5,7 @@ export default function PipelineDetailLayout() {
 	return (
 		<div>
 			<PipelineDetailHeader />
-			<section className="mx-auto w-full max-w-screen-xl p-5 lg:px-[80px]">
+			<section className="mx-auto w-full max-w-[1440px] p-5 lg:px-[80px]">
 				<Outlet />
 			</section>
 		</div>

--- a/src/app/pipelines/[pipelineId]/layout.tsx
+++ b/src/app/pipelines/[pipelineId]/layout.tsx
@@ -5,7 +5,7 @@ export default function PipelineDetailLayout() {
 	return (
 		<div>
 			<PipelineDetailHeader />
-			<section className="p-5 lg:px-[80px]">
+			<section className="mx-auto w-full max-w-screen-xl p-5 lg:px-[80px]">
 				<Outlet />
 			</section>
 		</div>

--- a/src/app/pipelines/[pipelineId]/runs/RunsTable.tsx
+++ b/src/app/pipelines/[pipelineId]/runs/RunsTable.tsx
@@ -32,7 +32,7 @@ export function PipelineRunsTable({ params, columns }: Props) {
 
 	return (
 		<div className="flex flex-col items-center gap-5">
-			<div className="w-full">
+			<div className="w-full overflow-x-auto">
 				<DataTable
 					rowSelection={rowSelection}
 					onRowSelectionChange={setRowSelection}

--- a/src/app/pipelines/_components/PipelinesBody.tsx
+++ b/src/app/pipelines/_components/PipelinesBody.tsx
@@ -29,7 +29,7 @@ export function PipelinesBody() {
 				</div>
 			</div>
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					{data ? (
 						<DataTable
 							rowSelection={rowSelection}

--- a/src/app/runs/RunsBody.tsx
+++ b/src/app/runs/RunsBody.tsx
@@ -36,7 +36,7 @@ export function RunsBody({ fixedQueryParams = {} }: Props) {
 				</div>
 			</div>
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					{data ? (
 						<DataTable
 							rowSelection={rowSelection}

--- a/src/app/settings/connectors/connector-list.tsx
+++ b/src/app/settings/connectors/connector-list.tsx
@@ -33,7 +33,7 @@ export function ServiceConnectorList({ queryParams }: Props) {
 	return (
 		<section className="flex flex-col gap-5">
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					<DataTable
 						columns={columns}
 						data={connectors.items}

--- a/src/app/settings/connectors/create/success/table.tsx
+++ b/src/app/settings/connectors/create/success/table.tsx
@@ -10,7 +10,7 @@ export function ConnectorSuccessTable({ connector }: Props) {
 	return (
 		<section className="flex flex-col gap-5">
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					<DataTable columns={columns} data={[connector]} />
 				</div>
 			</div>

--- a/src/app/settings/members/MembersTable.tsx
+++ b/src/app/settings/members/MembersTable.tsx
@@ -30,7 +30,7 @@ export default function MembersTable() {
 				{currentUser.body?.is_admin && <AddMemberDialog />}
 			</div>
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					{data ? (
 						<DataTable
 							columns={columns({ isAdmin: currentUser.body?.is_admin })}

--- a/src/app/settings/secrets/SecretsTable.tsx
+++ b/src/app/settings/secrets/SecretsTable.tsx
@@ -21,7 +21,7 @@ export default function SecretsTable() {
 				<AddSecretDialog />
 			</div>
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					{secretsData ? (
 						<DataTable columns={secretsColumns} data={secretsData.items} />
 					) : (

--- a/src/app/settings/secrets/[id]/SecretDetailTable.tsx
+++ b/src/app/settings/secrets/[id]/SecretDetailTable.tsx
@@ -54,7 +54,7 @@ export default function SecretDetailTable({ secretId }: { secretId: string }) {
 					/>
 				</Dialog>
 			</div>
-			<div className="w-full">
+			<div className="w-full overflow-x-auto">
 				<DataTable
 					columns={getSecretDetailColumn(secretId, secretDetail.data.name)}
 					data={filteredData}

--- a/src/app/settings/service-accounts/Table.tsx
+++ b/src/app/settings/service-accounts/Table.tsx
@@ -33,7 +33,7 @@ export function ServiceAccountsTable() {
 		<>
 			<Header />
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					{serviceAccounts ? (
 						<DataTable
 							getRowId={(row) => row.id}

--- a/src/app/settings/service-accounts/[service-account-id]/Table.tsx
+++ b/src/app/settings/service-accounts/[service-account-id]/Table.tsx
@@ -36,7 +36,7 @@ export default function ServiceAccountDetailTable() {
 			<Header serviceAccountId={serviceAccountId} />
 
 			<div className="flex flex-col items-center gap-5">
-				<div className="w-full">
+				<div className="w-full overflow-x-auto">
 					{serviceAccountApis ? (
 						<DataTable
 							getRowId={(row) => row.id}

--- a/src/app/snapshots/[snapshotId]/_layout/header/index.tsx
+++ b/src/app/snapshots/[snapshotId]/_layout/header/index.tsx
@@ -4,7 +4,7 @@ import { SnapshotDetailTabs } from "./tabs";
 export function SnapshotDetailHeader({ snapshotId }: { snapshotId: string }) {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="space-y-1 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-screen-xl space-y-1 px-5 pt-5 lg:px-[80px]">
 				<SnapshotDetailInfo snapshotId={snapshotId} />
 				<SnapshotDetailTabs />
 			</div>

--- a/src/app/snapshots/[snapshotId]/_layout/header/index.tsx
+++ b/src/app/snapshots/[snapshotId]/_layout/header/index.tsx
@@ -4,7 +4,7 @@ import { SnapshotDetailTabs } from "./tabs";
 export function SnapshotDetailHeader({ snapshotId }: { snapshotId: string }) {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="mx-auto w-full max-w-screen-xl space-y-1 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-[1440px] space-y-1 px-5 pt-5 lg:px-[80px]">
 				<SnapshotDetailInfo snapshotId={snapshotId} />
 				<SnapshotDetailTabs />
 			</div>

--- a/src/app/snapshots/[snapshotId]/layout.tsx
+++ b/src/app/snapshots/[snapshotId]/layout.tsx
@@ -6,7 +6,7 @@ export default function SnapshotDetailLayout() {
 	return (
 		<div>
 			<SnapshotDetailHeader snapshotId={snapshotId} />
-			<section className="mx-auto w-full max-w-screen-xl p-5 lg:px-[80px]">
+			<section className="mx-auto w-full max-w-[1440px] p-5 lg:px-[80px]">
 				<Outlet />
 			</section>
 		</div>

--- a/src/app/snapshots/[snapshotId]/layout.tsx
+++ b/src/app/snapshots/[snapshotId]/layout.tsx
@@ -6,7 +6,7 @@ export default function SnapshotDetailLayout() {
 	return (
 		<div>
 			<SnapshotDetailHeader snapshotId={snapshotId} />
-			<section className="p-5 lg:px-[80px]">
+			<section className="mx-auto w-full max-w-screen-xl p-5 lg:px-[80px]">
 				<Outlet />
 			</section>
 		</div>

--- a/src/app/stacks/StackList.tsx
+++ b/src/app/stacks/StackList.tsx
@@ -42,7 +42,7 @@ export function StackList({ fixedQueryParams = {} }: Props) {
 					</div>
 				</div>
 				<div className="flex flex-col items-center gap-5">
-					<div className="w-full">
+					<div className="w-full overflow-x-auto">
 						{data ? (
 							<DataTable columns={columns} data={data.items} />
 						) : (

--- a/src/components/deployments/list/table.tsx
+++ b/src/components/deployments/list/table.tsx
@@ -34,7 +34,7 @@ export function PipelineDeploymentsTable({ params, columns }: Props) {
 
 	return (
 		<div className="flex flex-col items-center gap-5">
-			<div className="w-full">
+			<div className="w-full overflow-x-auto">
 				<DataTable
 					columns={columns}
 					data={data.items}

--- a/src/components/pipeline-snapshots/list/table.tsx
+++ b/src/components/pipeline-snapshots/list/table.tsx
@@ -34,7 +34,7 @@ export function PipelineSnapshotsTable({ params, columns }: Props) {
 
 	return (
 		<div className="flex flex-col items-center gap-5">
-			<div className="w-full">
+			<div className="w-full overflow-x-auto">
 				<DataTable
 					columns={columns}
 					data={data.items}

--- a/src/components/stack-components/component-sheet/runs-tab/RunsList.tsx
+++ b/src/components/stack-components/component-sheet/runs-tab/RunsList.tsx
@@ -52,7 +52,7 @@ export function RunsList({ componentId }: Props) {
 					</div>
 				</div>
 				<div className="flex flex-col items-center gap-5">
-					<div className="w-full">
+					<div className="w-full overflow-x-auto">
 						{data ? (
 							<DataTable columns={runsColumns} data={data.items} />
 						) : (

--- a/src/components/stack-components/component-sheet/stacks-tab/StackList.tsx
+++ b/src/components/stack-components/component-sheet/stacks-tab/StackList.tsx
@@ -53,7 +53,7 @@ export function StackList({ componentId }: Props) {
 					</div>
 				</div>
 				<div className="flex flex-col items-center gap-5">
-					<div className="w-full">
+					<div className="w-full overflow-x-auto">
 						{data ? (
 							<DataTable columns={getStackColumnsPanel()} data={data.items} />
 						) : (

--- a/src/layouts/non-project-scoped/header.tsx
+++ b/src/layouts/non-project-scoped/header.tsx
@@ -4,7 +4,7 @@ import { NonProjectTabs } from "./tabs";
 export function Header() {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="space-y-3 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-screen-xl space-y-3 px-5 pt-5 lg:px-[80px]">
 				<NameSection />
 				<NonProjectTabs />
 			</div>

--- a/src/layouts/non-project-scoped/header.tsx
+++ b/src/layouts/non-project-scoped/header.tsx
@@ -4,7 +4,7 @@ import { NonProjectTabs } from "./tabs";
 export function Header() {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="mx-auto w-full max-w-screen-xl space-y-3 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-[1440px] space-y-3 px-5 pt-5 lg:px-[80px]">
 				<NameSection />
 				<NonProjectTabs />
 			</div>

--- a/src/layouts/non-project-scoped/layout.tsx
+++ b/src/layouts/non-project-scoped/layout.tsx
@@ -6,7 +6,7 @@ export function NonProjectScopedLayout() {
 		<div className="relative flex-1">
 			<Header />
 			<FloatingProgressLink />
-			<div className="px-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-screen-xl px-5 lg:px-[80px]">
 				<Outlet />
 			</div>
 		</div>

--- a/src/layouts/non-project-scoped/layout.tsx
+++ b/src/layouts/non-project-scoped/layout.tsx
@@ -6,7 +6,7 @@ export function NonProjectScopedLayout() {
 		<div className="relative flex-1">
 			<Header />
 			<FloatingProgressLink />
-			<div className="mx-auto w-full max-w-screen-xl px-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-[1440px] px-5 lg:px-[80px]">
 				<Outlet />
 			</div>
 		</div>

--- a/src/layouts/project-tabs/header.tsx
+++ b/src/layouts/project-tabs/header.tsx
@@ -3,7 +3,7 @@ import { ProjectTabs } from "./tabs";
 export function ProjectHeader() {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="mx-auto w-full max-w-screen-xl space-y-3 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-[1440px] space-y-3 px-5 pt-5 lg:px-[80px]">
 				<NameSection />
 				<ProjectTabs />
 			</div>

--- a/src/layouts/project-tabs/header.tsx
+++ b/src/layouts/project-tabs/header.tsx
@@ -3,7 +3,7 @@ import { ProjectTabs } from "./tabs";
 export function ProjectHeader() {
 	return (
 		<section className="overflow-x-hidden border-b border-theme-border-moderate bg-theme-surface-primary">
-			<div className="space-y-3 px-5 pt-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-screen-xl space-y-3 px-5 pt-5 lg:px-[80px]">
 				<NameSection />
 				<ProjectTabs />
 			</div>

--- a/src/layouts/project-tabs/layout.tsx
+++ b/src/layouts/project-tabs/layout.tsx
@@ -4,7 +4,7 @@ export function ProjectTabsLayout() {
 	return (
 		<div>
 			<ProjectHeader />
-			<div className="mx-auto w-full max-w-screen-xl p-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-[1440px] p-5 lg:px-[80px]">
 				<Outlet />
 			</div>
 		</div>

--- a/src/layouts/project-tabs/layout.tsx
+++ b/src/layouts/project-tabs/layout.tsx
@@ -4,7 +4,7 @@ export function ProjectTabsLayout() {
 	return (
 		<div>
 			<ProjectHeader />
-			<div className="p-5 lg:px-[80px]">
+			<div className="mx-auto w-full max-w-screen-xl p-5 lg:px-[80px]">
 				<Outlet />
 			</div>
 		</div>


### PR DESCRIPTION
Closes #887

## Summary

Two independent layout fixes for issue #887.

### Commit 1: overflow-x-auto on all DataTable wrappers

Adds `overflow-x-auto` to the `w-full` div wrapping every `DataTable` in the codebase (16 files). This is a defensive / consistency change — on the reporter's setup horizontal scrolling was already working, so the clipping described in the issue may depend on browser, OS scroll settings, or a specific viewport edge case. Adding `overflow-x-auto` makes the behavior explicit and uniform across all tables regardless of how parent overflow is configured, so it is low risk and worth keeping for correctness.

### Commit 2: cap content width at `max-w-[1440px]`

At 80% zoom so I notice the diff on my screen.

###### Staging

<img width="1552" height="902" alt="staging" src="https://github.com/user-attachments/assets/56ec3e72-5f91-44f1-9363-0aa7b9e3ba65" />

###### Fix

<img width="1552" height="902" alt="fix" src="https://github.com/user-attachments/assets/29864d8c-00f6-4522-84d4-74fd3d97ba3d" />

Adds `mx-auto w-full max-w-[1440px]` to all layout/header content containers across the project-tabs, non-project-scoped, pipeline detail, snapshot detail, and deployment detail layouts (11 files). Below 1440px the layout is unchanged. Above it the content column centers and the margins grow naturally instead of staying pinned at 80px regardless of viewport width.

**Why 1440px:** the codebase already defines a `.layout-container` utility class in `src/assets/styles/index.css` (`mx-auto w-11/12 max-w-[1440px]`) used by settings pages, stacks, overview, and other areas. This commit aligns the remaining layouts to that same cap so the max content width is consistent everywhere. If the design system changes the canonical value, `index.css` and these 11 files should be updated together.

## Test plan

- [x] At any viewport below 1440px: layout looks identical to staging
- [x] At 1440px+: content centers with growing side margins instead of stretching edge-to-edge
- [x] On mobile (e.g. iPhone 14 Pro Max 430px): tables with many columns show a horizontal scrollbar rather than clipping content
- [x] Header and content areas remain horizontally aligned at all widths