### PR TITLE
Align the "What's new" item with the other profile menu items

### DIFF
--- a/src/layouts/AuthenticatedLayout/whats-new-button.tsx
+++ b/src/layouts/AuthenticatedLayout/whats-new-button.tsx
@@ -8,13 +8,9 @@ type Props = {
 
 export default function WhatsNewButton({ openDialog }: Props) {
 	return (
-		<DropdownMenuItem
-			onSelect={() => openDialog()}
-			className="flex items-start gap-0.5 hover:cursor-pointer data-[highlighted]:bg-theme-surface-tertiary"
-			icon={<Speaker />}
-		>
+		<DropdownMenuItem onSelect={() => openDialog()} className="cursor-pointer" icon={<Speaker />}>
 			What's new
-			<AnnouncementIndicator />
+			<AnnouncementIndicator className="ml-0.5 self-start" />
 		</DropdownMenuItem>
 	);
 }


### PR DESCRIPTION
The "What's new" item in the profile dropdown used custom layout classes to position the announcement indicator. The gap also applied between the icon and the label, making the icon spacing wider than in the other menu items, and the icon was top aligned instead of vertically centered.

This removes the layout overrides so the item uses the standard `DropdownMenuItem` layout and moves the positioning to the indicator itself.

<details>

Before:

<img width="173" height="266" alt="Before the fix" src="https://github.com/user-attachments/assets/d6753231-48fc-45ec-b8ff-1b97a35e27e3" />

After:

<img width="179" height="289" alt="After the fix" src="https://github.com/user-attachments/assets/29b856e3-82c3-4a6e-90c3-be89c171de66" />

</details>