### PR TITLE
Update dependencies to fix open vulnerabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## General Context
 
 - This is a Vite-powered SPA that runs entirely client-side—no SSR considerations.
-- Routing is handled via `react-router-dom`; keep navigation centralized in `src/router` helpers.
+- Routing is handled via `react-router`; keep navigation centralized in `src/router` helpers.
 - The dashboard ships bundled with the FastAPI-based ZenML server, so API calls always target the paired backend instance with shared credentials.
 - Avoid duplicating code: inspect existing implementations (including `zenml-cloud-ui`) before adding new abstractions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Playwright uses `playwright.config.ts` as the source of truth. At the moment tha
 ## General OSS Practices
 
 - The dashboard is a pure Vite SPA—everything runs client-side, so no SSR plumbing is required.
-- Routing flows through `react-router-dom`; keep navigation centralized in router helpers rather than ad-hoc history calls.
+- Routing flows through `react-router`; keep navigation centralized in router helpers rather than ad-hoc history calls.
 - The OSS dashboard ships alongside the FastAPI ZenML server, so API requests always target the paired backend domain using shared cookies.
 - Avoid duplicating code or inventing hyper-generic abstractions: inspect existing flows (and `zenml-cloud-ui`) before writing new components or helpers.
 - Prefer focused components over catch-all versions; duplicating two purposeful components is often clearer than a single complex abstraction.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"react-json-view-lite": "^2.5.0",
 		"react-markdown": "^9.1.0",
 		"react-resizable-panels": "^3.0.6",
-		"react-router-dom": "^7.18.0",
+		"react-router": "^7.18.2",
 		"reactflow": "^11.11.4",
 		"remark-gfm": "^4.0.1",
 		"reodotdev": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"react-json-view-lite": "^2.5.0",
 		"react-markdown": "^9.1.0",
 		"react-resizable-panels": "^3.0.6",
-		"react-router-dom": "^6.30.4",
+		"react-router-dom": "^7.18.0",
 		"reactflow": "^11.11.4",
 		"remark-gfm": "^4.0.1",
 		"reodotdev": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify: ^3.4.12
-  js-yaml@4: ^4.3.0
+  brace-expansion@1: ^1.1.18
+  brace-expansion@2: ^2.1.4
+  brace-expansion@5: ^5.0.9
+  dompurify: ^3.4.13
+  js-yaml@3: ^3.15.1
+  js-yaml@4: ^4.3.1
+  nanoid@3: ^3.3.18
 
 importers:
 
@@ -103,8 +108,8 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       reactflow:
         specifier: ^11.11.4
         version: 11.11.4(@types/react@18.3.11)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -989,10 +994,6 @@ packages:
     resolution: {integrity: sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
-    engines: {node: '>=14.0.0'}
-
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1588,15 +1589,15 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1713,6 +1714,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -1818,8 +1823,8 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -2172,12 +2177,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsep@1.4.0:
@@ -2533,8 +2538,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2892,18 +2897,22 @@ packages:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  react-router-dom@6.30.4:
-    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
-    engines: {node: '>=14.0.0'}
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
 
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -2999,6 +3008,9 @@ packages:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3561,7 +3573,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4303,14 +4315,12 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
     transitivePeerDependencies:
       - supports-color
-
-  '@remix-run/router@1.23.3': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -4917,16 +4927,16 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5034,10 +5044,12 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -5121,7 +5133,7 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5456,12 +5468,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5481,7 +5493,7 @@ snapshots:
   json-schema-ref-parser@6.1.0:
     dependencies:
       call-me-maybe: 1.0.2
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       ono: 4.0.11
 
   json-schema-traverse@0.4.1: {}
@@ -5984,19 +5996,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       marked: 14.0.0
 
   ms@2.1.3: {}
@@ -6007,7 +6019,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -6173,7 +6185,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6301,17 +6313,19 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.4(react@18.3.1)
+      react-router: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router@6.30.4(react@18.3.1):
+  react-router@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      cookie: 1.1.1
       react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-style-singleton@2.2.3(@types/react@18.3.11)(react@18.3.1):
     dependencies:
@@ -6440,6 +6454,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.1: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ overrides:
   dompurify: ^3.4.13
   js-yaml@3: ^3.15.1
   js-yaml@4: ^4.3.1
-  nanoid@3: ^3.3.18
 
 importers:
 
@@ -1894,6 +1893,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
       react-resizable-panels:
         specifier: ^3.0.6
         version: 3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom:
-        specifier: ^7.18.0
+      react-router:
+        specifier: ^7.18.2
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       reactflow:
         specifier: ^11.11.4
@@ -2896,13 +2896,6 @@ packages:
     peerDependencies:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
 
   react-router@7.18.2:
     resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
@@ -6312,12 +6305,6 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   react-router@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,4 +17,3 @@ overrides:
   dompurify: "^3.4.13"
   js-yaml@3: "^3.15.1"
   js-yaml@4: "^4.3.1"
-  nanoid@3: "^3.3.18"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,5 +11,10 @@ minimumReleaseAge: 10080
 # Moved here from the "pnpm" field in package.json, which pnpm v10+ no longer reads
 # (it silently ignores overrides placed there and emits a [WARN] on every install).
 overrides:
-  dompurify: "^3.4.12"
-  js-yaml@4: "^4.3.0"
+  brace-expansion@1: "^1.1.18"
+  brace-expansion@2: "^2.1.4"
+  brace-expansion@5: "^5.0.9"
+  dompurify: "^3.4.13"
+  js-yaml@3: "^3.15.1"
+  js-yaml@4: "^4.3.1"
+  nanoid@3: "^3.3.18"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@zenml-io/react-component-library";
 import { Suspense } from "react";
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router";
 import { ReactFlowProvider } from "reactflow";
 import "reactflow/dist/style.css";
 import { AuthProvider } from "./context/AuthContext";

--- a/src/app/404.tsx
+++ b/src/app/404.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@zenml-io/react-component-library";
 import { EmptyState } from "../components/EmptyState";
 import Help from "@/assets/icons/help.svg?react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { routes } from "../router/routes";
 
 export default function Page404() {

--- a/src/app/activate-user/Wizard.tsx
+++ b/src/app/activate-user/Wizard.tsx
@@ -4,7 +4,7 @@ import StepDisplay from "@/components/survey/StepDisplay";
 import { SuccessStep } from "@/components/survey/SuccessStep";
 import { useSurveyContext } from "@/components/survey/SurveyContext";
 import { useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { AboutYouStep } from "./AboutYou";
 import { AccountDetailsStep } from "./AccountDetailsStep";
 import { ActivationProvider } from "./ActivationContext";

--- a/src/app/artifacts/Fragments.tsx
+++ b/src/app/artifacts/Fragments.tsx
@@ -1,6 +1,6 @@
 import { Codesnippet } from "@/components/CodeSnippet";
 import { Box } from "@zenml-io/react-component-library";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 export function CommandSection() {
 	const [searchParams] = useSearchParams();

--- a/src/app/components/StackComponentList.tsx
+++ b/src/app/components/StackComponentList.tsx
@@ -7,7 +7,7 @@ import { routes } from "@/router/routes";
 import { useQuery } from "@tanstack/react-query";
 import { DataTable } from "@zenml-io/react-component-library";
 import { Button, Skeleton } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { getComponentList } from "./columns";
 import { useComponentlistQueryParams } from "./service";
 import { StackComponentListParams } from "@/types/components";

--- a/src/app/components/[componentId]/edit/form-step.tsx
+++ b/src/app/components/[componentId]/edit/form-step.tsx
@@ -1,7 +1,7 @@
 import { Button, Skeleton } from "@zenml-io/react-component-library";
 import { useId } from "react";
 import * as Wizard from "@/components/wizard/Wizard";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { componentQueries } from "@/data/components";
 import { useQuery } from "@tanstack/react-query";
 import { routes } from "@/router/routes";

--- a/src/app/components/[componentId]/layout.tsx
+++ b/src/app/components/[componentId]/layout.tsx
@@ -1,5 +1,5 @@
 import { StackComponentsDetailHeader } from "@/components/stack-components/component-detail/Header";
-import { Outlet, useParams } from "react-router-dom";
+import { Outlet, useParams } from "react-router";
 
 export default function ComponentLayout() {
 	const { componentId } = useParams() as { componentId: string };

--- a/src/app/components/[componentId]/page.tsx
+++ b/src/app/components/[componentId]/page.tsx
@@ -1,5 +1,5 @@
 import { StackComponentTabs } from "@/components/stack-components/component-detail/Tabs";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { RunsBody } from "../../runs/RunsBody";
 import { RunsSelectorContextProvider } from "../../runs/RunsSelectorContext";
 import { StackList } from "../../stacks/StackList";

--- a/src/app/components/component-dropdown.tsx
+++ b/src/app/components/component-dropdown.tsx
@@ -10,7 +10,7 @@ import {
 	DropdownMenuTrigger
 } from "@zenml-io/react-component-library/components/client";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useComponentBulkDelete } from "./selector-context";
 type Props = {
 	id: string;

--- a/src/app/components/create/config-step.tsx
+++ b/src/app/components/create/config-step.tsx
@@ -7,7 +7,7 @@ import { StackComponentType } from "@/types/components";
 import { Flavor } from "@/types/flavors";
 import { Button } from "@zenml-io/react-component-library/components/server";
 import { useId } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 type Props = {
 	flavor: Flavor;

--- a/src/app/components/service.ts
+++ b/src/app/components/service.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { StackComponentListParams } from "@/types/components";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 const DEFAULT_PAGE = 1;
 

--- a/src/app/deployments/[deploymentId]/_components/fetch-wrapper.tsx
+++ b/src/app/deployments/[deploymentId]/_components/fetch-wrapper.tsx
@@ -3,7 +3,7 @@ import { Deployment } from "@/types/deployments";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@zenml-io/react-component-library/components/server";
 import { ComponentType } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 type DeploymentDetailWrapperProps = {
 	Component: ComponentType<{ deployment: Deployment }>;

--- a/src/app/deployments/[deploymentId]/_layout/header/pipeline-tag.tsx
+++ b/src/app/deployments/[deploymentId]/_layout/header/pipeline-tag.tsx
@@ -1,7 +1,7 @@
 import PipelineIcon from "@/assets/icons/pipeline.svg?react";
 import { routes } from "@/router/routes";
 import { Tag } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 type Props = {
 	pipelineId: string;
 	pipelineName: string;

--- a/src/app/deployments/[deploymentId]/_layout/header/tabs.tsx
+++ b/src/app/deployments/[deploymentId]/_layout/header/tabs.tsx
@@ -10,7 +10,7 @@ import {
 	TabsList,
 	TabsTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useActiveTab } from "./use-active-tab";
 
 export function DeploymentDetailTabs() {

--- a/src/app/deployments/[deploymentId]/layout.tsx
+++ b/src/app/deployments/[deploymentId]/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useParams } from "react-router-dom";
+import { Outlet, useParams } from "react-router";
 import { DeploymentDetailHeader } from "./_layout/header";
 
 export default function DeploymentDetailLayout() {

--- a/src/app/deployments/[deploymentId]/playground/_components/outputs/run-card.tsx
+++ b/src/app/deployments/[deploymentId]/playground/_components/outputs/run-card.tsx
@@ -3,7 +3,7 @@ import { RunName } from "@/components/runs/run-name";
 import { secondsToTimeString } from "@/lib/dates";
 import { routes } from "@/router/routes";
 import { Box, Button } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { PlaygroundRunCardAvatar } from "./run-card-avatar";
 
 type Props = {

--- a/src/app/deployments/[deploymentId]/playground/page.tsx
+++ b/src/app/deployments/[deploymentId]/playground/page.tsx
@@ -3,7 +3,7 @@ import { pipelineSnapshotQueries } from "@/data/pipeline-snapshots";
 import { IS_SAFARI } from "@/lib/environment";
 import "@/monaco-setup";
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { PlaygroundEmptyState, PlaygroundError } from "./_components/error";
 import { PlaygroundLoader } from "./_components/loader";
 import { PlaygroundPageContent } from "./page.content";

--- a/src/app/deployments/[deploymentId]/runs/page.content.tsx
+++ b/src/app/deployments/[deploymentId]/runs/page.content.tsx
@@ -3,7 +3,7 @@ import { RunsTableToolbar } from "@/app/pipelines/[pipelineId]/runs/runs-table-t
 import { PipelineRunsTable } from "@/app/pipelines/[pipelineId]/runs/RunsTable";
 import { usePipelineRunParams } from "@/app/pipelines/[pipelineId]/runs/service";
 import { PipelineRunOvervieweParams } from "@/types/pipeline-runs";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export function DeploymentRunsContent() {
 	const params = usePipelineRunParams();

--- a/src/app/devices/verify/service.ts
+++ b/src/app/devices/verify/service.ts
@@ -1,5 +1,5 @@
 import { DeviceQueryParams } from "@/types/devices";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { z } from "zod";
 

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -7,7 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Input, useToast } from "@zenml-io/react-component-library";
 import { useId } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 export function LoginForm() {
 	const navigate = useNavigate();

--- a/src/app/models/Fragments.tsx
+++ b/src/app/models/Fragments.tsx
@@ -1,6 +1,6 @@
 import { Codesnippet } from "@/components/CodeSnippet";
 import { Box } from "@zenml-io/react-component-library";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 export function CommandSection() {
 	const [searchParams] = useSearchParams();

--- a/src/app/onboarding/Setup/index.tsx
+++ b/src/app/onboarding/Setup/index.tsx
@@ -6,7 +6,7 @@ import { routes } from "@/router/routes";
 import { OnboardingResponse } from "@/types/onboarding";
 import { Skeleton } from "@zenml-io/react-component-library";
 import { useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ConnectZenMLStep, DeployPipeline, RunFirstPipeline } from "./Items";
 
 export function OnboardingSetupList() {

--- a/src/app/overview/next-steps.tsx
+++ b/src/app/overview/next-steps.tsx
@@ -4,7 +4,7 @@ import Calendar from "@/assets/icons/calendar.svg?react";
 import Slack from "@/assets/icons/services/slack.svg?react";
 import { cn } from "@zenml-io/react-component-library/utilities";
 import { routes } from "@/router/routes";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function NextSteps() {
 	return (

--- a/src/app/overview/page.tsx
+++ b/src/app/overview/page.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { SuccessBanner } from "./success-banner";
 import { SupportResources } from "./support-resources";
 import { Templates } from "./templates";

--- a/src/app/overview/success-banner.tsx
+++ b/src/app/overview/success-banner.tsx
@@ -1,6 +1,6 @@
 import CheckCircle from "@/assets/icons/check-circle.svg?react";
 import X from "@/assets/icons/close.svg?react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 export function SuccessBanner() {
 	const navigate = useNavigate();

--- a/src/app/pipelines/[pipelineId]/_layout/name-section.tsx
+++ b/src/app/pipelines/[pipelineId]/_layout/name-section.tsx
@@ -3,7 +3,7 @@ import { ExecutionStatusIcon, getExecutionStatusColor } from "@/components/Execu
 import { pipelineQueries } from "@/data/pipelines";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@zenml-io/react-component-library/components/server";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useActiveTab } from "./use-active-tab";
 import { usePipelineDetailRunsBreadcrumbs } from "./use-breadcrumb";
 import { capitalize } from "@/lib/strings";

--- a/src/app/pipelines/[pipelineId]/_layout/tabs.tsx
+++ b/src/app/pipelines/[pipelineId]/_layout/tabs.tsx
@@ -10,7 +10,7 @@ import {
 	TabsList,
 	TabsTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useActiveTab } from "./use-active-tab";
 
 export function PipelineDetailTabs() {

--- a/src/app/pipelines/[pipelineId]/deployments/page.content.tsx
+++ b/src/app/pipelines/[pipelineId]/deployments/page.content.tsx
@@ -2,7 +2,7 @@ import { PipelineDeploymentsTable } from "@/components/deployments/list/table";
 import { DeploymentsTableToolbar } from "@/components/deployments/list/toolbar";
 import { useDeploymentQueryParams } from "@/components/deployments/list/use-deployment-queryparams";
 import { DeploymentsListQueryParams } from "@/types/deployments";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { usePipelineDeploymentColumns } from "./columns";
 
 export function PipelineDeploymentsContent() {

--- a/src/app/pipelines/[pipelineId]/layout.tsx
+++ b/src/app/pipelines/[pipelineId]/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { PipelineDetailHeader } from "./_layout/header";
 
 export default function PipelineDetailLayout() {

--- a/src/app/pipelines/[pipelineId]/runs/columns.tsx
+++ b/src/app/pipelines/[pipelineId]/runs/columns.tsx
@@ -20,7 +20,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { RunDropdown } from "../../../runs/RunDropdown";
 
 export function getPipelineDetailColumns(): ColumnDef<PipelineRun>[] {

--- a/src/app/pipelines/[pipelineId]/runs/content.tsx
+++ b/src/app/pipelines/[pipelineId]/runs/content.tsx
@@ -1,5 +1,5 @@
 import { PipelineRunOvervieweParams } from "@/types/pipeline-runs";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { getPipelineDetailColumns } from "./columns";
 import { RunsTableToolbar } from "./runs-table-toolbar";
 import { PipelineRunsTable } from "./RunsTable";

--- a/src/app/pipelines/[pipelineId]/runs/service.ts
+++ b/src/app/pipelines/[pipelineId]/runs/service.ts
@@ -1,5 +1,5 @@
 import { PipelineRunOvervieweParams } from "@/types/pipeline-runs";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const DEFAULT_PAGE = 1;

--- a/src/app/pipelines/[pipelineId]/snapshots/page.content.tsx
+++ b/src/app/pipelines/[pipelineId]/snapshots/page.content.tsx
@@ -1,5 +1,5 @@
 import { PipelineSnapshotListQueryParams } from "@/types/pipeline-snapshots";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { SnapshotTableToolbar } from "@/components/pipeline-snapshots/list/toolbar";
 import { PipelineSnapshotsTable } from "@/components/pipeline-snapshots/list/table";
 import { useSnapshotListQueryParams } from "@/components/pipeline-snapshots/list/use-queryparams";

--- a/src/app/pipelines/_components/columns.tsx
+++ b/src/app/pipelines/_components/columns.tsx
@@ -14,7 +14,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { PipelineDropdown } from "./PipelineDropdown";
 
 export function getPipelineColumns(): ColumnDef<Pipeline>[] {

--- a/src/app/pipelines/_components/service.ts
+++ b/src/app/pipelines/_components/service.ts
@@ -1,5 +1,5 @@
 import { PipelineListParams } from "@/types/pipelines";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { z } from "zod";
 

--- a/src/app/projects/project-item.tsx
+++ b/src/app/projects/project-item.tsx
@@ -17,7 +17,7 @@ import {
 	TooltipTrigger
 } from "@zenml-io/react-component-library";
 import { Box, Skeleton } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { ProjectMenu } from "./project-menu";
 
 type Props = {

--- a/src/app/projects/project-menu.tsx
+++ b/src/app/projects/project-menu.tsx
@@ -7,7 +7,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger
 } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { DefaultProjectHandler } from "./set-default-project";
 
 type Props = {

--- a/src/app/runs/[id]/_layout/DeleteRunAlert.tsx
+++ b/src/app/runs/[id]/_layout/DeleteRunAlert.tsx
@@ -2,7 +2,7 @@ import AlertCircle from "@/assets/icons/alert-circle.svg?react";
 import Tick from "@/assets/icons/tick-circle.svg?react";
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertDialog, useToast } from "@zenml-io/react-component-library";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { DeleteAlertContent, DeleteAlertContentBody } from "@/components/DeleteAlertDialog";
 import { useDeleteRun } from "@/data/pipeline-runs/delete-run";
 import { routes } from "@/router/routes";

--- a/src/app/runs/[id]/_layout/Header.tsx
+++ b/src/app/runs/[id]/_layout/Header.tsx
@@ -3,7 +3,7 @@ import { RunRefreshGroup } from "@/components/runs/refresh-group";
 import { RunsDetailHeaderNameSection } from "@/components/runs/runs-detail-header-name-section";
 import { RunStopGroup } from "@/components/runs/stop-group";
 import { usePipelineRun } from "@/data/pipeline-runs/pipeline-run-detail-query";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useRunDetailBreadcrumbs } from "./breadcrumbs";
 import { RunActionsMenu } from "./RunActionMenu";
 import { PipelineRunDetailTabs } from "./tabs";

--- a/src/app/runs/[id]/_layout/RunActionMenu.tsx
+++ b/src/app/runs/[id]/_layout/RunActionMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from "@zenml-io/react-component-library";
 import { useState } from "react";
 import { DeleteRunAlert } from "./DeleteRunAlert";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { routes } from "@/router/routes";
 
 type Props = {

--- a/src/app/runs/[id]/_layout/layout.tsx
+++ b/src/app/runs/[id]/_layout/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { RunsDetailHeader } from "./Header";
 
 export function RunDetailLayout() {

--- a/src/app/runs/[id]/_layout/tabs.tsx
+++ b/src/app/runs/[id]/_layout/tabs.tsx
@@ -11,7 +11,7 @@ import {
 	TabsList,
 	TabsTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useActivePipelineRunTab } from "./use-active-pipeline-run-tab";
 
 export function PipelineRunDetailTabs() {

--- a/src/app/runs/[id]/create-snapshot/page.tsx
+++ b/src/app/runs/[id]/create-snapshot/page.tsx
@@ -1,6 +1,6 @@
 import { CreateSnapshotForm } from "@/components/pipeline-snapshots/create/form";
 import { usePipelineRun } from "@/data/pipeline-runs/pipeline-run-detail-query";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useCreateSnapshotFromRunBreadcrumbs } from "./breadcrumb";
 
 export default function CreateSnapshotFromRunPage() {

--- a/src/app/runs/[id]/detail-tabs.tsx
+++ b/src/app/runs/[id]/detail-tabs.tsx
@@ -1,7 +1,7 @@
 import Collapse from "@/assets/icons/collapse.svg?react";
 import { RunDetailTabsDisplay } from "@/components/runs/detail-tabs";
 import { Button } from "@zenml-io/react-component-library";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { useSelectedTab } from "../../../components/runs/detail-tabs/service";
 
 type TabsHeaderProps = {

--- a/src/app/runs/[id]/logs/components/log-viewer/index.tsx
+++ b/src/app/runs/[id]/logs/components/log-viewer/index.tsx
@@ -2,7 +2,7 @@ import { LogTab } from "@/components/runs/detail-tabs/LogTab/logs";
 import { RunsDetailHeaderNameSection } from "@/components/runs/runs-detail-header-name-section";
 import { StepLogsTab } from "@/components/steps/step-sheet/LogsTab";
 import { SheetHeadline } from "@/components/steps/step-sheet/sheet-headline";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useSelectedStep } from "../use-selected-step";
 import { PipelineRunLogsViewerHeader } from "./header";
 import { LogViewerSidebarToggleButton } from "./sidebar-toggle-button";

--- a/src/app/runs/[id]/logs/components/sidebar/run-section.tsx
+++ b/src/app/runs/[id]/logs/components/sidebar/run-section.tsx
@@ -3,7 +3,7 @@ import { usePipelineRun } from "@/data/pipeline-runs/pipeline-run-detail-query";
 import { calculateTimeDifference } from "@/lib/dates";
 import { Skeleton } from "@zenml-io/react-component-library";
 import { useMemo } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router";
 import { useSelectedStep } from "../use-selected-step";
 import { PipelineRunLogSidebarItem } from "./common";
 import { ExecutionStatusIcon } from "@/components/ExecutionStatus";

--- a/src/app/runs/[id]/logs/components/sidebar/step-section.tsx
+++ b/src/app/runs/[id]/logs/components/sidebar/step-section.tsx
@@ -3,7 +3,7 @@ import { prepareBackendTimestamp, secondsToTimeString } from "@/lib/dates";
 import { RawStepNode } from "@/types/dag-visualizer";
 import type { ExecutionStatus, ExecutionStatusFilterValue } from "@/types/pipeline-runs";
 import { Skeleton } from "@zenml-io/react-component-library/components/server";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useSelectedStep } from "../use-selected-step";
 import { useRef } from "react";
 import { useVirtualizedList } from "./use-virtualized-list";

--- a/src/app/runs/[id]/logs/components/use-selected-step.tsx
+++ b/src/app/runs/[id]/logs/components/use-selected-step.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const stepIdSchema = z.string().uuid();

--- a/src/app/runs/[id]/not-found.tsx
+++ b/src/app/runs/[id]/not-found.tsx
@@ -1,7 +1,7 @@
 import AlertCircle from "@/assets/icons/alert-circle.svg?react";
 import ArrowLeft from "@/assets/icons/arrow-left.svg?react";
 import { Button } from "@zenml-io/react-component-library";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 export default function RunNotFound() {
 	const navigate = useNavigate();

--- a/src/app/runs/[id]/page.tsx
+++ b/src/app/runs/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { RunsDetailTabs, TabsHeader } from "./detail-tabs";
 import { ExpandPanelButton, GlobalDagControls } from "./expand-panel-button";
 import { PipelineVisualization } from "./pipeline-viz";

--- a/src/app/runs/columns.tsx
+++ b/src/app/runs/columns.tsx
@@ -19,7 +19,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { RunDropdown } from "./RunDropdown";
 
 export const runsColumns: ColumnDef<PipelineRun>[] = [

--- a/src/app/runs/service.ts
+++ b/src/app/runs/service.ts
@@ -1,5 +1,5 @@
 import { PipelineRunOvervieweParams } from "@/types/pipeline-runs";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const DEFAULT_PAGE = 1;

--- a/src/app/settings/api-tokens/APITokenModal.tsx
+++ b/src/app/settings/api-tokens/APITokenModal.tsx
@@ -16,7 +16,7 @@ import { jwtDecode } from "jwt-decode";
 import { useState } from "react";
 import Countdown, { CountdownRendererFn } from "react-countdown";
 import { ErrorBoundary } from "react-error-boundary";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type Props = {
 	token: string;

--- a/src/app/settings/connectors/[id]/components/page.tsx
+++ b/src/app/settings/connectors/[id]/components/page.tsx
@@ -1,6 +1,6 @@
 import { ComponentSelectorContextProvider } from "@/app/components/selector-context";
 import { StackComponentList } from "@/app/components/StackComponentList";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export default function ConnectorComponentPage() {
 	const { connectorId } = useParams() as { connectorId: string };

--- a/src/app/settings/connectors/[id]/configuration/configuration.tsx
+++ b/src/app/settings/connectors/[id]/configuration/configuration.tsx
@@ -3,7 +3,7 @@ import { serviceConnectorQueries } from "@/data/service-connectors";
 import { extractAuthMethod } from "@/lib/service-connectors";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@zenml-io/react-component-library/components/server";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export function ConfigurationPanel() {
 	const { connectorId } = useParams() as { connectorId: string };

--- a/src/app/settings/connectors/[id]/configuration/params.tsx
+++ b/src/app/settings/connectors/[id]/configuration/params.tsx
@@ -17,7 +17,7 @@ import {
 } from "@zenml-io/react-component-library/components/client";
 import { Skeleton, Tag } from "@zenml-io/react-component-library/components/server";
 import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export function BasicParams() {
 	const [open, setOpen] = useState(true);

--- a/src/app/settings/connectors/[id]/resources/verify-button.tsx
+++ b/src/app/settings/connectors/[id]/resources/verify-button.tsx
@@ -5,7 +5,7 @@ import { useResourcesContext } from "@/layouts/connectors-detail/resources-conte
 import { useQuery } from "@tanstack/react-query";
 import { Button, Skeleton } from "@zenml-io/react-component-library";
 import { ReactNode, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { LoadingDialog } from "./loading-dialog";
 
 export function VerifyButton({ children }: { children: ReactNode }) {

--- a/src/app/settings/connectors/columns.tsx
+++ b/src/app/settings/connectors/columns.tsx
@@ -11,7 +11,7 @@ import { ServiceConnector } from "@/types/service-connectors";
 import { ColumnDef } from "@tanstack/react-table";
 import { Checkbox } from "@zenml-io/react-component-library";
 import { useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { ConnectorDropdown } from "./connector-dropdown";
 
 export function useServiceConnectorListColumns(): ColumnDef<ServiceConnector>[] {

--- a/src/app/settings/connectors/create/common/footer-buttons.tsx
+++ b/src/app/settings/connectors/create/common/footer-buttons.tsx
@@ -2,7 +2,7 @@ import { Button } from "@zenml-io/react-component-library/components/server";
 import ArrowLeft from "@/assets/icons/arrow-left.svg?react";
 import { useWizardContext } from "@/context/WizardContext";
 import { ButtonHTMLAttributes } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { routes } from "@/router/routes";
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement>;

--- a/src/app/settings/connectors/create/success/index.tsx
+++ b/src/app/settings/connectors/create/success/index.tsx
@@ -1,7 +1,7 @@
 import * as Wizard from "@/components/wizard/Wizard";
 import { routes } from "@/router/routes";
 import { Button } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useRegisterConnectorContext } from "../create-context";
 import { ConnectorSuccessBox } from "./success-box";
 import { ConnectorSuccessTable } from "./table";

--- a/src/app/settings/connectors/new-connector-button.tsx
+++ b/src/app/settings/connectors/new-connector-button.tsx
@@ -2,7 +2,7 @@ import { Button } from "@zenml-io/react-component-library/components/server";
 import Plus from "@/assets/icons/plus.svg?react";
 import { routes } from "@/router/routes";
 
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 export function NewConnectorButton() {
 	return (
 		<Button size="md" asChild>

--- a/src/app/settings/connectors/use-connector-params.ts
+++ b/src/app/settings/connectors/use-connector-params.ts
@@ -1,5 +1,5 @@
 import { ServiceConnectorListQueryParams } from "@/types/service-connectors";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const DEFAULT_PAGE = 1;

--- a/src/app/settings/mcp/components/TokenSection.tsx
+++ b/src/app/settings/mcp/components/TokenSection.tsx
@@ -6,7 +6,7 @@ import { routes } from "@/router/routes";
 import { Button, Input } from "@zenml-io/react-component-library/components/server";
 import CheckCircle from "@/assets/icons/check-circle.svg?react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type TokenSectionProps = {
 	token: string | null;

--- a/src/app/settings/members/service.ts
+++ b/src/app/settings/members/service.ts
@@ -1,5 +1,5 @@
 import { ListUserParams } from "@/types/user";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { z } from "zod";
 

--- a/src/app/settings/secrets/[id]/page.tsx
+++ b/src/app/settings/secrets/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { secretQueries } from "@/data/secrets";
 import { useQuery } from "@tanstack/react-query";
 import { Box } from "@zenml-io/react-component-library";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { CopyButton } from "../../../../components/CopyButton";
 import SecretDetailTable from "./SecretDetailTable";
 import { useSecretDetailBreadcrumbs } from "./breadcrumbs";

--- a/src/app/settings/secrets/columns.tsx
+++ b/src/app/settings/secrets/columns.tsx
@@ -7,7 +7,7 @@ import { getSecretSnippet } from "@/lib/code-snippets";
 import { routes } from "@/router/routes";
 import { SecretNamespace } from "@/types/secret";
 import { ColumnDef } from "@tanstack/react-table";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import SecretsDropdown from "./SecretsDropdown";
 import { SecretTooltip } from "./SecretTooltip";
 

--- a/src/app/settings/secrets/service.ts
+++ b/src/app/settings/secrets/service.ts
@@ -1,5 +1,5 @@
 import { ListSecretsParams } from "@/types/secret";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { z } from "zod";
 

--- a/src/app/settings/service-accounts/[service-account-id]/Fallback.tsx
+++ b/src/app/settings/service-accounts/[service-account-id]/Fallback.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@zenml-io/react-component-library/components/server";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { AddApiKeyDialog } from "./AddApiKeyDialog";
 
 export default function ApiKeyFallback() {

--- a/src/app/settings/service-accounts/[service-account-id]/Table.tsx
+++ b/src/app/settings/service-accounts/[service-account-id]/Table.tsx
@@ -4,7 +4,7 @@ import { serviceAccountQueries } from "@/data/service-accounts";
 import { useQuery } from "@tanstack/react-query";
 import { DataTable, Skeleton } from "@zenml-io/react-component-library";
 import { useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useServiceAccountOverviewSearchParams } from "../service";
 import { AddApiKeyDialog } from "./AddApiKeyDialog";
 import { ApiKeyButtonGroup } from "./ButtonGroup";

--- a/src/app/settings/service-accounts/[service-account-id]/header.tsx
+++ b/src/app/settings/service-accounts/[service-account-id]/header.tsx
@@ -2,7 +2,7 @@ import { ServiceAccountAvatar } from "@/components/avatars/service-account-avata
 import { serviceAccountQueries } from "@/data/service-accounts";
 import { useQuery } from "@tanstack/react-query";
 import { Badge, Skeleton } from "@zenml-io/react-component-library/components/server";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useServiceAccountDetailBreadcrumbs } from "./breadcrumb";
 
 export function APIKeyHeader() {

--- a/src/app/settings/service-accounts/columns.tsx
+++ b/src/app/settings/service-accounts/columns.tsx
@@ -4,7 +4,7 @@ import { routes } from "@/router/routes";
 import { ServiceAccount } from "@/types/service-accounts";
 import { ColumnDef } from "@tanstack/react-table";
 import { Checkbox } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import ServiceAccountsDropdown from "./Dropdown";
 import ToggleActiveServiceAccount from "./ToggleServiceAccount";
 

--- a/src/app/settings/service-accounts/service.ts
+++ b/src/app/settings/service-accounts/service.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { ListServiceAccountsParams } from "@/types/service-accounts";
 import { z } from "zod";

--- a/src/app/snapshots/[snapshotId]/_components/fetch-wrapper.tsx
+++ b/src/app/snapshots/[snapshotId]/_components/fetch-wrapper.tsx
@@ -3,7 +3,7 @@ import { PipelineSnapshot } from "@/types/pipeline-snapshots";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@zenml-io/react-component-library/components/server";
 import { ComponentType } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 type SnapshotDetailWrapperProps = {
 	Component: ComponentType<{ snapshot: PipelineSnapshot }>;

--- a/src/app/snapshots/[snapshotId]/_components/snapshot-detail.tsx
+++ b/src/app/snapshots/[snapshotId]/_components/snapshot-detail.tsx
@@ -14,7 +14,7 @@ import {
 	CollapsibleTrigger
 } from "@zenml-io/react-component-library";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { SnapshotDetailWrapper } from "./fetch-wrapper";
 
 export function SnapshotDetails() {

--- a/src/app/snapshots/[snapshotId]/_components/snapshot-stack.tsx
+++ b/src/app/snapshots/[snapshotId]/_components/snapshot-stack.tsx
@@ -3,7 +3,7 @@ import { pipelineSnapshotQueries } from "@/data/pipeline-snapshots";
 import { stackQueries } from "@/data/stacks";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@zenml-io/react-component-library/components/server";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export function SnapshotStack() {
 	const { snapshotId } = useParams() as {

--- a/src/app/snapshots/[snapshotId]/_layout/header/tabs.tsx
+++ b/src/app/snapshots/[snapshotId]/_layout/header/tabs.tsx
@@ -9,7 +9,7 @@ import {
 	TabsList,
 	TabsTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useActiveTab } from "./use-active-tab";
 
 export function SnapshotDetailTabs() {

--- a/src/app/snapshots/[snapshotId]/layout.tsx
+++ b/src/app/snapshots/[snapshotId]/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useParams } from "react-router-dom";
+import { Outlet, useParams } from "react-router";
 import { SnapshotDetailHeader } from "./_layout/header";
 
 export default function SnapshotDetailLayout() {

--- a/src/app/snapshots/[snapshotId]/runs/page.content.tsx
+++ b/src/app/snapshots/[snapshotId]/runs/page.content.tsx
@@ -4,7 +4,7 @@ import { PipelineRunsTable } from "@/app/pipelines/[pipelineId]/runs/RunsTable";
 import { usePipelineRunParams } from "@/app/pipelines/[pipelineId]/runs/service";
 import { PipelineRunOvervieweParams } from "@/types/pipeline-runs";
 import { useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export function SnapshotDetailRunsContent() {
 	const params = usePipelineRunParams();

--- a/src/app/stacks/ActionsDropdown.tsx
+++ b/src/app/stacks/ActionsDropdown.tsx
@@ -9,7 +9,7 @@ import {
 	DropdownMenuTrigger
 } from "@zenml-io/react-component-library";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { DeleteStackAlert } from "./DeleteStackModal";
 import { useDeleteStack } from "./useDeleteStack";
 

--- a/src/app/stacks/ResumeStackBanner.tsx
+++ b/src/app/stacks/ResumeStackBanner.tsx
@@ -4,7 +4,7 @@ import { routes } from "@/router/routes";
 import { useQuery } from "@tanstack/react-query";
 import { Button, Skeleton } from "@zenml-io/react-component-library";
 import { Dispatch, SetStateAction, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { clearWizardData, parseWizardData } from "./create/new-infrastructure/persist";
 
 type Props = {

--- a/src/app/stacks/ResumeTerraformBanner.tsx
+++ b/src/app/stacks/ResumeTerraformBanner.tsx
@@ -4,7 +4,7 @@ import { routes } from "@/router/routes";
 import { useQuery } from "@tanstack/react-query";
 import { Button, Skeleton } from "@zenml-io/react-component-library";
 import { Dispatch, SetStateAction, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { clearWizardData, parseWizardData } from "./create/terraform/persist";
 
 type Props = {

--- a/src/app/stacks/StackList.tsx
+++ b/src/app/stacks/StackList.tsx
@@ -6,7 +6,7 @@ import { stackQueries } from "@/data/stacks";
 import { routes } from "@/router/routes";
 import { useQuery } from "@tanstack/react-query";
 import { Button, DataTable, Skeleton } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useStacklistQueryParams } from "./service";
 import { StackListQueryParams } from "../../types/stack";
 import { useStackColumns } from "./columns";

--- a/src/app/stacks/[stackId]/edit/layout.tsx
+++ b/src/app/stacks/[stackId]/edit/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { StackHeader } from "./stack-header";
 
 export default function EditStacksLayout() {

--- a/src/app/stacks/[stackId]/edit/page.tsx
+++ b/src/app/stacks/[stackId]/edit/page.tsx
@@ -2,7 +2,7 @@ import { stackQueries } from "@/data/stacks";
 import { stackComponentTypes } from "@/lib/constants";
 import { useQuery } from "@tanstack/react-query";
 import { Spinner } from "@zenml-io/react-component-library";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { transformStackToFormData } from "./transform-component-data";
 import { UpdateForm } from "./update-form";
 import { useStackUpdateBreadcrumbs } from "./use-breadcrumbs";

--- a/src/app/stacks/[stackId]/edit/stack-header.tsx
+++ b/src/app/stacks/[stackId]/edit/stack-header.tsx
@@ -3,7 +3,7 @@ import { PageHeader } from "@/components/PageHeader";
 import { stackQueries } from "@/data/stacks";
 import { useQuery } from "@tanstack/react-query";
 import { Avatar, AvatarFallback, Skeleton } from "@zenml-io/react-component-library";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export function StackHeader() {
 	const { stackId } = useParams() as { stackId: string };

--- a/src/app/stacks/[stackId]/edit/use-update-stack.tsx
+++ b/src/app/stacks/[stackId]/edit/use-update-stack.tsx
@@ -6,7 +6,7 @@ import { routes } from "@/router/routes";
 import { StackComponentType } from "@/types/components";
 import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@zenml-io/react-component-library";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { FormType } from "../../create/manual/schema";
 
 export function useUpdateStackHook(stackId: string) {

--- a/src/app/stacks/[stackId]/stack-page-boundary.tsx
+++ b/src/app/stacks/[stackId]/stack-page-boundary.tsx
@@ -3,7 +3,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { PageBoundary } from "@/error-boundaries/PageBoundary";
 import { routes } from "@/router/routes";
 import { Button } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function StackPageBoundary() {
 	return (

--- a/src/app/stacks/create/ExistingInfra.tsx
+++ b/src/app/stacks/create/ExistingInfra.tsx
@@ -12,7 +12,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router";
 import { LocalOverlay } from "./LocalOverlay";
 import * as OptionsCard from "./OptionCard";
 

--- a/src/app/stacks/create/NewInfra.tsx
+++ b/src/app/stacks/create/NewInfra.tsx
@@ -12,7 +12,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router";
 import { LocalOverlay } from "./LocalOverlay";
 import * as OptionsCard from "./OptionCard";
 

--- a/src/app/stacks/create/components/CancelButton.tsx
+++ b/src/app/stacks/create/components/CancelButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@zenml-io/react-component-library/components/server";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { clearWizardData } from "../new-infrastructure/persist";
 import { routes } from "@/router/routes";
 

--- a/src/app/stacks/create/existing-infrastructure/steps/final/index.tsx
+++ b/src/app/stacks/create/existing-infrastructure/steps/final/index.tsx
@@ -10,7 +10,7 @@ import { Stack } from "@/types/stack";
 import { useQuery } from "@tanstack/react-query";
 import { Avatar, AvatarFallback } from "@zenml-io/react-component-library/components/client";
 import { Button, Skeleton } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { StackWizardFooter } from "../../../components/WizardFooter";
 import { useExistingInfraContext } from "../../ExistingInfraContext";
 import { FlavorIcon } from "../../FlavorIcon";

--- a/src/app/stacks/create/layout.tsx
+++ b/src/app/stacks/create/layout.tsx
@@ -1,6 +1,6 @@
 import Stack from "@/assets/icons/stack.svg?react";
 import { PageHeader } from "@/components/PageHeader";
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { useStackCreateBreadcrumbs } from "./breadcrumb";
 
 export function CreateStacksLayout() {

--- a/src/app/stacks/create/manual/useManualStack.tsx
+++ b/src/app/stacks/create/manual/useManualStack.tsx
@@ -7,7 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@zenml-io/react-component-library";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { FormType, formSchema } from "./schema";
 
 export function useManualStack() {

--- a/src/app/stacks/create/new-infrastructure/Wizard.tsx
+++ b/src/app/stacks/create/new-infrastructure/Wizard.tsx
@@ -2,7 +2,7 @@ import { useWizardContext } from "@/context/WizardContext";
 import { routes } from "@/router/routes";
 import { Box, Button } from "@zenml-io/react-component-library";
 import { ReactNode } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 import { CancelButton } from "../components/CancelButton";
 import { useNewInfraFormContext } from "./NewInfraFormContext";
 import { ConfigurationStep } from "./Steps/Configuration";

--- a/src/app/stacks/create/terraform/steps/deploy/index.tsx
+++ b/src/app/stacks/create/terraform/steps/deploy/index.tsx
@@ -10,7 +10,7 @@ import { routes } from "@/router/routes";
 import { StackDeploymentProvider } from "@/types/stack";
 import { useQuery } from "@tanstack/react-query";
 import { Button, Skeleton } from "@zenml-io/react-component-library/components/server";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { StackWizardFooter } from "../../../components/WizardFooter";
 import { clearWizardData } from "../../persist";
 import { useCreateTerraformContext } from "../../TerraformContext";

--- a/src/app/stacks/create/terraform/steps/success/index.tsx
+++ b/src/app/stacks/create/terraform/steps/success/index.tsx
@@ -3,7 +3,7 @@ import { routes } from "@/router/routes";
 import { Button } from "@zenml-io/react-component-library/components/server";
 import { StackWizardFooter } from "../../../components/WizardFooter";
 import { useCreateTerraformContext } from "../../TerraformContext";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { SuccessList } from "../../../new-infrastructure/Steps/Success/SuccessList";
 
 export function SuccessStep() {

--- a/src/app/stacks/service.ts
+++ b/src/app/stacks/service.ts
@@ -1,5 +1,5 @@
 import { StackListQueryParams } from "@/types/stack";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const DEFAULT_PAGE = 1;

--- a/src/app/stacks/useDeleteStack.tsx
+++ b/src/app/stacks/useDeleteStack.tsx
@@ -4,7 +4,7 @@ import { useDeleteStackMutation } from "@/data/stacks/delete-stack";
 import { routes } from "@/router/routes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@zenml-io/react-component-library";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 export function useDeleteStack(stackId: string, closeAlert?: () => void) {
 	const { toast } = useToast();

--- a/src/app/upgrade/components/Success.tsx
+++ b/src/app/upgrade/components/Success.tsx
@@ -2,7 +2,7 @@ import CheckCircle from "@/assets/icons/check-circle.svg?react";
 import { Tick } from "@/components/pro/ProCta";
 import { routes } from "@/router/routes";
 import { Button } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 const contents = [
 	"Comprehensive documentation to get started",

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -6,7 +6,7 @@ import { analyticsServerUrl } from "@/lib/analytics";
 import { routes } from "@/router/routes";
 import { PageEvent, PageEventContext, PageEventPage, PageEventProperties } from "@/types/analytics";
 import { useEffect } from "react";
-import { matchPath, useLocation } from "react-router-dom";
+import { matchPath, useLocation } from "react-router";
 
 const REO_KEY = import.meta.env.VITE_REO_KEY;
 

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,4 +1,4 @@
-import { NavLink as NavLinkPrimitive, NavLinkProps, useLocation } from "react-router-dom";
+import { NavLink as NavLinkPrimitive, NavLinkProps, useLocation } from "react-router";
 
 interface CustomNavLinkProps extends NavLinkProps {
 	isActiveOverride?: (pathname: string) => boolean;
@@ -16,7 +16,7 @@ export default function NavLink({ children, isActiveOverride, ...rest }: CustomN
 					isActive || defaultIsActive
 						? "bg-primary-50 text-theme-text-brand"
 						: "hover:bg-neutral-200"
-				} block rounded-md px-4 py-1 text-text-sm font-semibold `
+				} block rounded-md px-4 py-1 text-text-sm font-semibold`
 			}
 		>
 			{children}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -6,7 +6,7 @@ import Right from "@/assets/icons/chevron-right.svg?react";
 import { objectToSearchParams } from "@/lib/url";
 import { forwardRef } from "react";
 import { cn } from "@zenml-io/react-component-library";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ResponsePage } from "@/types/common";
 
 type Props = {

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -4,7 +4,7 @@ import { objectToSearchParams } from "@/lib/url";
 import { cn, Input } from "@zenml-io/react-component-library";
 import debounce from "lodash.debounce";
 import { InputHTMLAttributes, forwardRef, useEffect, useMemo, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 type Props = {
 	inMemoryHandler?: (val: string) => void;

--- a/src/components/artifacts/artifact-node-sheet/DetailCards.tsx
+++ b/src/components/artifacts/artifact-node-sheet/DetailCards.tsx
@@ -21,7 +21,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { Codesnippet } from "../../CodeSnippet";
 import { CollapsibleCard } from "../../CollapsibleCard";
 import { DownloadArtifactButton } from "../download-artifact-button";

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import Divider from "@/assets/icons/slash-divider.svg?react";
 import { Fragment, useEffect, useState, useCallback } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { BreadcrumbSegment } from "./types";
 import { useBreadcrumbsContext } from "@/layouts/AuthenticatedLayout/BreadcrumbsContext";
 import { dashCaseToTitleCase } from "@/lib/strings";

--- a/src/components/breadcrumbs/project-link.tsx
+++ b/src/components/breadcrumbs/project-link.tsx
@@ -8,7 +8,7 @@ import {
 	TooltipTrigger
 } from "@zenml-io/react-component-library/components/client";
 import { Button } from "@zenml-io/react-component-library/components/server";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 
 export function ProjectLink() {
 	const pathname = useLocation().pathname;

--- a/src/components/breadcrumbs/workspace-link.tsx
+++ b/src/components/breadcrumbs/workspace-link.tsx
@@ -11,7 +11,7 @@ import {
 } from "@zenml-io/react-component-library/components/client";
 
 import { Button, Skeleton } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function WorkspaceLink() {
 	const server = useServerInfo();

--- a/src/components/deployments/list/column-definitions.tsx
+++ b/src/components/deployments/list/column-definitions.tsx
@@ -9,7 +9,7 @@ import { getFirstUuidSegment } from "@/lib/strings";
 import { routes } from "@/router/routes";
 import { Deployment } from "@/types/deployments";
 import { ColumnDef } from "@tanstack/react-table";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function createDeploymentNameColumn(): ColumnDef<Deployment> {
 	return {

--- a/src/components/deployments/list/use-deployment-queryparams.ts
+++ b/src/components/deployments/list/use-deployment-queryparams.ts
@@ -1,5 +1,5 @@
 import { DeploymentsListQueryParams } from "@/types/deployments";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const DEFAULT_PAGE = 1;

--- a/src/components/onboarding/floating-progress-link.tsx
+++ b/src/components/onboarding/floating-progress-link.tsx
@@ -3,7 +3,7 @@ import { useServerInfo } from "@/data/server/info-query";
 import { getOnboardingSetup } from "@/lib/onboarding";
 import { Box, ProgressBar, RadialProgress, Skeleton } from "@zenml-io/react-component-library";
 import { checkIsLocalServer } from "@/lib/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { routes } from "@/router/routes";
 import Rocket from "@/assets/icons/rocket.svg?react";
 

--- a/src/components/pipeline-snapshots/create/_form-components/create-snapshot-form-footer.tsx
+++ b/src/components/pipeline-snapshots/create/_form-components/create-snapshot-form-footer.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@zenml-io/react-component-library";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 type Props = {
 	isPending: boolean;

--- a/src/components/pipeline-snapshots/create/use-submit-handler.ts
+++ b/src/components/pipeline-snapshots/create/use-submit-handler.ts
@@ -4,7 +4,7 @@ import { useUpdateSnapshot } from "@/data/pipeline-snapshots/update-snapshot";
 import { routes } from "@/router/routes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@zenml-io/react-component-library";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { CreatePipelineSnapshotFormSchema } from "./form-schema";
 
 export function useSubmitHandler(originalSnapshotId: string | null) {

--- a/src/components/pipeline-snapshots/list/column-definitions.tsx
+++ b/src/components/pipeline-snapshots/list/column-definitions.tsx
@@ -11,7 +11,7 @@ import { routes } from "@/router/routes";
 import { PipelineSnapshot } from "@/types/pipeline-snapshots";
 import { ColumnDef } from "@tanstack/react-table";
 import { Checkbox } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { PipelineSnapshotActions } from "../table-actions";
 
 export function createSnapshotCheckColumn(): ColumnDef<PipelineSnapshot> {

--- a/src/components/pipeline-snapshots/list/toolbar.tsx
+++ b/src/components/pipeline-snapshots/list/toolbar.tsx
@@ -7,7 +7,7 @@ import { routes } from "@/router/routes";
 import { PipelineSnapshotListQueryParams } from "@/types/pipeline-snapshots";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { PipelineSnapshotsButtonGroup } from "./button-group";
 
 type Props = {

--- a/src/components/pipeline-snapshots/list/use-queryparams.ts
+++ b/src/components/pipeline-snapshots/list/use-queryparams.ts
@@ -1,5 +1,5 @@
 import { PipelineSnapshotListQueryParams } from "@/types/pipeline-snapshots";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const DEFAULT_PAGE = 1;

--- a/src/components/pipeline-snapshots/snapshot-link.tsx
+++ b/src/components/pipeline-snapshots/snapshot-link.tsx
@@ -2,7 +2,7 @@ import SnapshotIcon from "@/assets/icons/snapshot.svg?react";
 import { routes } from "@/router/routes";
 import { Tag } from "@zenml-io/react-component-library";
 import { ComponentProps } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type Props = ComponentProps<typeof Tag> & {
 	snapshotId: string;

--- a/src/components/pipelines/pipeline-link.tsx
+++ b/src/components/pipelines/pipeline-link.tsx
@@ -1,7 +1,7 @@
 import { routes } from "@/router/routes";
 import { cn, Tag } from "@zenml-io/react-component-library";
 import { ComponentPropsWithoutRef } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import PipelineIcon from "@/assets/icons/pipeline.svg?react";
 
 type Props = ComponentPropsWithoutRef<typeof Tag> & {

--- a/src/components/pro/ProCta.tsx
+++ b/src/components/pro/ProCta.tsx
@@ -2,7 +2,7 @@ import { Badge, Button } from "@zenml-io/react-component-library/components/serv
 import { cn } from "@zenml-io/react-component-library/utilities";
 import Check from "@/assets/icons/check.svg?react";
 import { HTMLAttributes, ImgHTMLAttributes } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { routes } from "@/router/routes";
 
 export function ProWrapper({ className, ...rest }: HTMLAttributes<HTMLDivElement>) {

--- a/src/components/runs/detail-tabs/Overview/Details.tsx
+++ b/src/components/runs/detail-tabs/Overview/Details.tsx
@@ -27,7 +27,7 @@ import {
 	TooltipTrigger
 } from "@zenml-io/react-component-library";
 import { useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 import { DeploymentTag } from "./deployment-tag";
 import { RunStatusTag } from "../../run-status-tag";
 

--- a/src/components/runs/detail-tabs/Overview/deployment-tag.tsx
+++ b/src/components/runs/detail-tabs/Overview/deployment-tag.tsx
@@ -3,7 +3,7 @@ import { deploymentQueries } from "@/data/deployments";
 import { routes } from "@/router/routes";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type Props = {
 	deploymentId: string;

--- a/src/components/runs/detail-tabs/service.ts
+++ b/src/components/runs/detail-tabs/service.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const tabParamSchema = z.object({

--- a/src/components/runs/run-sheet/index.tsx
+++ b/src/components/runs/run-sheet/index.tsx
@@ -5,7 +5,7 @@ import { EmptyState } from "@/components/EmptyState";
 import AlertCircle from "@/assets/icons/alert-circle.svg?react";
 import { RunSheetHeadline } from "./headline";
 import { Button } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { routes } from "@/router/routes";
 import Maximize from "@/assets/icons/expand-full.svg?react";
 

--- a/src/components/runs/run-status-tag.tsx
+++ b/src/components/runs/run-status-tag.tsx
@@ -2,7 +2,7 @@ import RunIcon from "@/assets/icons/terminal-square.svg?react";
 import { routes } from "@/router/routes";
 import { ExecutionStatus } from "@/types/pipeline-runs";
 import { Tag } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { getExecutionStatusTagColor } from "../ExecutionStatus";
 
 type Props = {

--- a/src/components/service-connectors/connector-tag.tsx
+++ b/src/components/service-connectors/connector-tag.tsx
@@ -1,7 +1,7 @@
 import Transform from "@/assets/icons/transform.svg?react";
 import { routes } from "@/router/routes";
 import { Tag } from "@zenml-io/react-component-library/components/server";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type Props = {
 	connectorName: string;

--- a/src/components/stack-components/component-detail/Header.tsx
+++ b/src/components/stack-components/component-detail/Header.tsx
@@ -6,7 +6,7 @@ import { sanitizeUrl } from "@/lib/url";
 import { routes } from "@/router/routes";
 import { Badge, Button, Skeleton } from "@zenml-io/react-component-library/components/server";
 import { useEffect } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { useBreadcrumbsContext } from "../../../layouts/AuthenticatedLayout/BreadcrumbsContext";
 import { CopyButton } from "../../CopyButton";
 import { PageHeader } from "../../PageHeader";

--- a/src/components/stack-components/component-detail/Tabs.tsx
+++ b/src/components/stack-components/component-detail/Tabs.tsx
@@ -5,7 +5,7 @@ import { TabIcon } from "@/components/tab-icon";
 import { ScrollingTabsList } from "@/components/tabs/scrolling-tabs-list";
 import { Tabs, TabsContent, TabsTrigger } from "@zenml-io/react-component-library";
 import { ReactNode, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ComponentConfigTab } from "./ConfigTab";
 import { useSelectedTab } from "./service";
 

--- a/src/components/stack-components/component-detail/service.ts
+++ b/src/components/stack-components/component-detail/service.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import { z } from "zod";
 
 const tabParamSchema = z.object({

--- a/src/components/stack-components/component-sheet/index.tsx
+++ b/src/components/stack-components/component-sheet/index.tsx
@@ -5,7 +5,7 @@ import { routes } from "@/router/routes";
 import { Sheet, SheetTrigger } from "@zenml-io/react-component-library";
 import { Button } from "@zenml-io/react-component-library/components/server";
 import { PropsWithChildren } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { StackComponentsDetailHeader } from "../component-detail/Header";
 import { StackComponentTabs } from "../component-detail/Tabs";
 import { RunsList } from "./runs-tab/RunsList";

--- a/src/components/stack-components/component-sheet/runs-tab/columns.tsx
+++ b/src/components/stack-components/component-sheet/runs-tab/columns.tsx
@@ -12,7 +12,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export const runsColumns: ColumnDef<PipelineRun>[] = [
 	{

--- a/src/components/stacks/Sheet/ComponentList.tsx
+++ b/src/components/stacks/Sheet/ComponentList.tsx
@@ -8,7 +8,7 @@ import { StackComponent } from "@/types/components";
 import { useQuery } from "@tanstack/react-query";
 import { Badge, Box, Skeleton } from "@zenml-io/react-component-library";
 import { useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { CopyButton } from "../../CopyButton";
 import { ComponentBadge } from "../../stack-components/ComponentBadge";
 import { useIntegrationsContext } from "./IntegrationsContext";

--- a/src/components/stacks/Sheet/StackHeadline.tsx
+++ b/src/components/stacks/Sheet/StackHeadline.tsx
@@ -3,7 +3,7 @@ import { stackQueries } from "@/data/stacks";
 import { routes } from "@/router/routes";
 import { useQuery } from "@tanstack/react-query";
 import { Avatar, AvatarFallback, Button, Skeleton } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { CopyButton } from "../../CopyButton";
 
 type Props = {

--- a/src/components/stacks/edit-create/button-bar.tsx
+++ b/src/components/stacks/edit-create/button-bar.tsx
@@ -2,7 +2,7 @@ import { stackQueries } from "@/data/stacks";
 import { useIsMutating } from "@tanstack/react-query";
 import { Button } from "@zenml-io/react-component-library/components/server";
 import { useFormContext } from "react-hook-form";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 type StackFormButtonBarProps = {
 	cancelRoute: string;

--- a/src/components/stacks/info/stack-info-component-list-item.tsx
+++ b/src/components/stacks/info/stack-info-component-list-item.tsx
@@ -8,7 +8,7 @@ import { StackComponent, StackComponentType } from "@/types/components";
 import { Badge, Box } from "@zenml-io/react-component-library/components/server";
 import { cn } from "@zenml-io/react-component-library/utilities";
 import { PropsWithChildren } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { NestedCollapsible } from "../../NestedCollapsible";
 
 type Props = {

--- a/src/components/steps/step-sheet/ConfigurationTab.tsx
+++ b/src/components/steps/step-sheet/ConfigurationTab.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/lib/docker-images";
 import { AnyDict } from "@/types/common";
 import { Skeleton } from "@zenml-io/react-component-library";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { ErrorFallback } from "../../Error";
 import { NestedCollapsible } from "../../NestedCollapsible";
 

--- a/src/components/steps/step-sheet/DetailsTab.tsx
+++ b/src/components/steps/step-sheet/DetailsTab.tsx
@@ -16,7 +16,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger
 } from "@zenml-io/react-component-library";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { Codesnippet } from "../../CodeSnippet";
 import { CollapsibleCard } from "../../CollapsibleCard";
 import { DisplayDate } from "../../DisplayDate";

--- a/src/components/steps/step-sheet/SheetContent.tsx
+++ b/src/components/steps/step-sheet/SheetContent.tsx
@@ -10,7 +10,7 @@ import { TabIcon } from "@/components/tab-icon";
 import { ScrollingTabsList } from "@/components/tabs/scrolling-tabs-list";
 import { Tabs, TabsContent, TabsTrigger } from "@zenml-io/react-component-library";
 import { ErrorBoundary } from "react-error-boundary";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { StepCodeTab } from "./CodeTab";
 import { StepConfigTab } from "./ConfigurationTab";
 import { OrchestratorCard, StepDetailsTab } from "./DetailsTab";

--- a/src/components/steps/step-sheet/StacksTab.tsx
+++ b/src/components/steps/step-sheet/StacksTab.tsx
@@ -5,7 +5,7 @@ import { usePipelineRun } from "@/data/pipeline-runs/pipeline-run-detail-query";
 import { useStack } from "@/data/stacks/stack-detail-query";
 import { useStepDetail } from "@/data/steps/step-detail-query";
 import { Skeleton } from "@zenml-io/react-component-library";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { EmptyState } from "../../EmptyState";
 
 type Props = {

--- a/src/components/steps/step-sheet/sheet-headline.tsx
+++ b/src/components/steps/step-sheet/sheet-headline.tsx
@@ -2,7 +2,7 @@ import { getIsStatusUnknown } from "@/components/dag-visualizer/layout/status";
 import { usePipelineRun } from "@/data/pipeline-runs/pipeline-run-detail-query";
 import { useStepDetail } from "@/data/steps/step-detail-query";
 import { Badge, Skeleton } from "@zenml-io/react-component-library";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import {
 	ExecutionStatusIcon,
 	getBadgeColor,

--- a/src/components/survey/SuccessStep.tsx
+++ b/src/components/survey/SuccessStep.tsx
@@ -4,7 +4,7 @@ import { urlSchema } from "@/lib/url";
 import { routes } from "@/router/routes";
 import { Box, Button } from "@zenml-io/react-component-library";
 import { ReactNode } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router";
 
 type Props = {
 	username: string;

--- a/src/components/tour/StartTourDialog.tsx
+++ b/src/components/tour/StartTourDialog.tsx
@@ -7,7 +7,7 @@ import {
 	Button
 } from "@zenml-io/react-component-library";
 import { useTourContext } from "./TourContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { routes } from "@/router/routes";
 import TourImage from "@/assets/images/product-tour/tour-cover.webp";
 

--- a/src/components/tour/Tour.tsx
+++ b/src/components/tour/Tour.tsx
@@ -3,7 +3,7 @@ import { routes } from "@/router/routes";
 import { Button, cn } from "@zenml-io/react-component-library";
 import Joyride, { CallBackProps, EVENTS, Step, TooltipRenderProps } from "react-joyride";
 import { useTourContext } from "./TourContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useUpdateCurrentUserMutation } from "@/data/users/update-current-user-mutation";
 import { getCurrentUserKey, useCurrentUser } from "@/data/users/current-user-query";
 import { getUserMetadata } from "@/lib/user-metadata";

--- a/src/error-boundaries/PageBoundary.tsx
+++ b/src/error-boundaries/PageBoundary.tsx
@@ -1,6 +1,6 @@
 import { isNotFoundError } from "@/lib/not-found-error";
 import { PropsWithChildren } from "react";
-import { useRouteError } from "react-router-dom";
+import { useRouteError } from "react-router";
 
 export function PageBoundary({ children }: PropsWithChildren) {
 	const error = useRouteError();

--- a/src/error-boundaries/RootBoundary.tsx
+++ b/src/error-boundaries/RootBoundary.tsx
@@ -1,4 +1,4 @@
-import { useRouteError } from "react-router-dom";
+import { useRouteError } from "react-router";
 import AlertCircle from "@/assets/icons/alert-circle.svg?react";
 
 export function RootBoundary() {

--- a/src/hooks/use-route-segment.tsx
+++ b/src/hooks/use-route-segment.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 export function useRouteSegment(index = 1) {
 	const { pathname } = useLocation();

--- a/src/hooks/usePageTitle.ts
+++ b/src/hooks/usePageTitle.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import { matchPath, useLocation } from "react-router-dom";
+import { matchPath, useLocation } from "react-router";
 import { routes } from "@/router/routes";
 
 /**

--- a/src/layouts/AuthenticatedLayout/AuthenticatedHeader.tsx
+++ b/src/layouts/AuthenticatedLayout/AuthenticatedHeader.tsx
@@ -3,7 +3,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs/Breadcrumbs";
 import { ProjectLink } from "@/components/breadcrumbs/project-link";
 import { WorkspaceLink } from "@/components/breadcrumbs/workspace-link";
 import { routes } from "@/router/routes";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { BackButton } from "./back-button";
 import { UserDropdown } from "./UserDropdown";
 

--- a/src/layouts/AuthenticatedLayout/UserDropdown.tsx
+++ b/src/layouts/AuthenticatedLayout/UserDropdown.tsx
@@ -19,7 +19,7 @@ import {
 	DropdownMenuTrigger,
 	Skeleton
 } from "@zenml-io/react-component-library";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import AnnouncementButton from "./whats-new-button";
 import { useAnnouncement } from "./use-announcement";
 import { AnnouncementIndicator } from "@/components/announcements/announcement-indicator";

--- a/src/layouts/AuthenticatedLayout/back-button.tsx
+++ b/src/layouts/AuthenticatedLayout/back-button.tsx
@@ -1,6 +1,6 @@
 import ArrowLeft from "@/assets/icons/arrow-left.svg?react";
 import { Button } from "@zenml-io/react-component-library/components/server";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 export function BackButton() {
 	const navigate = useNavigate();

--- a/src/layouts/AuthenticatedLayout/index.tsx
+++ b/src/layouts/AuthenticatedLayout/index.tsx
@@ -4,7 +4,7 @@ import { useServerSettings } from "@/data/server/get-server-settings";
 import { useCurrentUser } from "@/data/users/current-user-query";
 import { checkUserOnboarding } from "@/lib/user";
 import { routes } from "@/router/routes";
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet } from "react-router";
 import { AuthenticatedHeader } from "./AuthenticatedHeader";
 import { BreadcrumbContextProvider } from "./BreadcrumbsContext";
 import { LocalBanner } from "./LocalBanner";

--- a/src/layouts/GradientLayout.tsx
+++ b/src/layouts/GradientLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import Gradient from "@/assets/images/gradient_bg.webp";
 import ZenML from "@/assets/icons/zenml.svg?react";
 

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,7 +1,7 @@
 import { useServerInfo } from "@/data/server/info-query";
 import { routes } from "@/router/routes";
 import { useEffect } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
 export function RootLayout() {

--- a/src/layouts/connectors-detail/header.tsx
+++ b/src/layouts/connectors-detail/header.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from "@zenml-io/react-component-library/components/server";
 import { useConnectorDetailBreadcrumbs } from "./breadcrumbs";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { CopyButton } from "@/components/CopyButton";
 import { useQuery } from "@tanstack/react-query";
 import { serviceConnectorQueries } from "@/data/service-connectors";

--- a/src/layouts/connectors-detail/layout.tsx
+++ b/src/layouts/connectors-detail/layout.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@zenml-io/react-component-library/components/server";
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { ConnectorDetailHeader } from "./header";
 import { ResourcesContextProvider } from "./resources-context";
 import { ServiceConnectorTabs } from "./tabs";

--- a/src/layouts/connectors-detail/tabs.tsx
+++ b/src/layouts/connectors-detail/tabs.tsx
@@ -11,7 +11,7 @@ import {
 	TabsTrigger
 } from "@zenml-io/react-component-library/components/client";
 import { ReactNode } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 export function ServiceConnectorTabs({ children }: { children: ReactNode }) {
 	const navigate = useNavigate();

--- a/src/layouts/non-project-scoped/dropdown.tsx
+++ b/src/layouts/non-project-scoped/dropdown.tsx
@@ -7,7 +7,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger
 } from "@zenml-io/react-component-library";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function NonProjectScopedDropdown() {
 	return (

--- a/src/layouts/non-project-scoped/layout.tsx
+++ b/src/layouts/non-project-scoped/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { Header } from "./header";
 import { FloatingProgressLink } from "@/components/onboarding/floating-progress-link";
 export function NonProjectScopedLayout() {

--- a/src/layouts/non-project-scoped/tabs.tsx
+++ b/src/layouts/non-project-scoped/tabs.tsx
@@ -7,7 +7,7 @@ import {
 	TabsList,
 	TabsTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 // settings is in brackets because of the file structure
 type TabValues = "projects" | "stacks" | "components" | "settings" | "overview";

--- a/src/layouts/project-tabs/layout.tsx
+++ b/src/layouts/project-tabs/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { ProjectHeader } from "./header";
 export function ProjectTabsLayout() {
 	return (

--- a/src/layouts/project-tabs/tabs.tsx
+++ b/src/layouts/project-tabs/tabs.tsx
@@ -7,7 +7,7 @@ import {
 	TabsList,
 	TabsTrigger
 } from "@zenml-io/react-component-library/components/client";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 // settings is in brackets because of the file structure
 

--- a/src/layouts/settings/project-settings/layout.tsx
+++ b/src/layouts/settings/project-settings/layout.tsx
@@ -1,7 +1,7 @@
 import { InlineAvatar } from "@/components/InlineAvatar";
 import { useCurrentUser } from "@/data/users/current-user-query";
 import { Skeleton } from "@zenml-io/react-component-library";
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { DisplayProject } from "./project-display";
 import { routes } from "@/router/routes";
 import { SettingsMenu } from "../Menu";

--- a/src/layouts/settings/settings-layout/layout.tsx
+++ b/src/layouts/settings/settings-layout/layout.tsx
@@ -1,7 +1,7 @@
 import { InlineAvatar } from "@/components/InlineAvatar";
 import { useCurrentUser } from "@/data/users/current-user-query";
 import { Skeleton } from "@zenml-io/react-component-library";
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { DisplayServer, ProfileSettingsMenu, ServerSettingsMenu } from "./LayoutSidebar";
 import { VersionDisplay } from "./VersionDisplay";
 

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, ReactNode } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useAuthContext } from "../context/AuthContext";
 import { useServerInfo } from "../data/server/info-query";
 import { routes } from "./routes";

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -10,7 +10,7 @@ import { NonProjectScopedLayout } from "@/layouts/non-project-scoped/layout";
 import { ProjectTabsLayout } from "@/layouts/project-tabs/layout";
 import { ProjectSettingsLayout } from "@/layouts/settings/project-settings/layout";
 import { lazy } from "react";
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter } from "react-router";
 import { PageBoundary } from "../error-boundaries/PageBoundary";
 import { GradientLayout } from "../layouts/GradientLayout";
 import { RootLayout } from "../layouts/RootLayout";


### PR DESCRIPTION
## Summary

- Upgrade React Router to the patched 7.x release.
- Override vulnerable transitive versions of `brace-expansion`, `dompurify`, `js-yaml`, and `nanoid`.
- Regenerate the pnpm lockfile.

This resolves the Dependabot security alerts, including denial-of-service, open-redirect/XSS, and DOM sanitization vulnerabilities.
